### PR TITLE
chore: add yarn to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 node_modules
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+yarn-error.log


### PR DESCRIPTION
Adds `.yarn` and related directories to gitignore.