### PR TITLE
remove recursive yarn calls and simplify lint steps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "Backend for Find a Doc, Japan",
   "main": "index.js",
   "scripts": {
-    "prepare": "yarn && husky install",
+    "prepare": "husky install",
     "test": "ts-mocha src/tests/**.ts",
     "dev": "yarn && ts-node-dev --transpile-only --no-notify --exit-child src/index.ts",
     "generate": "yarn && graphql-codegen --config ./typesgeneratorconfig.ts",
-    "lint": "yarn && eslint . --ext .js,.ts,.json && prettier --write **/*.{js,ts,json}",
-    "lint:check": "yarn && eslint . --ext .js,.ts,.json && prettier --check **/*.{js,ts,json}",
+    "lint": "eslint . --ext .js,.ts,.json && prettier --write **/*.{js,ts,json}",
+    "lint:check": "eslint . --ext .js,.ts,.json && prettier --check **/*.{js,ts,json}",
     "prestart": "yarn generate",
     "predev": "yarn generate"
   },


### PR DESCRIPTION
I think #20 introduced an anti-pattern, calling yarn inside yarn is kinda dangerous.

1. `package.json` is run by yarn, and the `prepare` script is special in that it is a [lifecycle script](https://nodejs.org/en/), it runs automatically:

> Runs BEFORE the package is packed, i.e. during npm publish and npm pack
> 
> Runs on local npm install without any arguments
> 
> Runs AFTER prepublish, but BEFORE prepublishOnly
> 
> NOTE: If a package being installed through git contains a prepare script, its dependencies and devDependencies will be installed, and the prepare script will be run, before the package is packaged and installed.
> 
> As of npm@7 these scripts run in the background. To see the output, run with: --foreground-scripts.

So running `yarn` locally to install things means the `prepare` script automatically runs, and the prepare script calls `yarn`... and now we're in an infinite loop

2. We need to keep the linting step as light as possible as it's integrated into Husky hooks. We should not be downloading things or building on a lint.

3. I'm unsure if installing before `dev` and `build` is a good idea. Normally if I wanted to do everything in one go, I'd think the `bash` / `zsh` command `yarn && yarn dev` might be a better plan. Thoughts?