### PR TITLE
add mutations for HealthcareProfessional

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
   "dependencies": {
     "apollo-server": "^3.8.2",
     "chai": "^4.3.6",
-    "crypto": "^1.0.1",
     "graphql": "^16.5.0",
     "graphql-import-node": "^0.0.5",
     "mocha": "^10.0.0",

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -31,7 +31,7 @@ const resolvers = {
   },
   Mutation: {
     createHealthcareProfessional: (_parent: any, args: any) => {
-      const id = crypto.randomBytes(10).toString("hex");
+      const id = crypto.randomUUID();
 
       const {
         names,
@@ -45,7 +45,7 @@ const resolvers = {
       specialties.map((specialty: { id: string }) => {
         if (!specialty.id) {
           // eslint-disable-next-line no-param-reassign
-          specialty.id = crypto.randomBytes(10).toString("hex");
+          specialty.id = crypto.randomUUID();
         }
         return specialty.id;
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,13 +3358,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "crypto@npm:1.0.1"
-  checksum: 087fe3165bd94c333a49e6ed66a0193911f63eac38a24f379b3001a5fe260a59c413646e53a0f67875ba13902b2686d81dc703cb2c147a4ec727dcdc04e5645e
-  languageName: node
-  linkType: hard
-
 "cssfilter@npm:0.0.10":
   version: 0.0.10
   resolution: "cssfilter@npm:0.0.10"
@@ -4263,7 +4256,6 @@ __metadata:
     "@typescript-eslint/parser": ^5.31.0
     apollo-server: ^3.8.2
     chai: ^4.3.6
-    crypto: ^1.0.1
     eslint: ^8.20.0
     eslint-config-airbnb-base: ^15.0.0
     eslint-config-airbnb-typescript: ^17.0.0


### PR DESCRIPTION
# Part of #30 


## Documentation

Here is the documentation that was referenced to write the mutations and input types: [Documentation](https://graphql.org/graphql-js/mutations-and-input-types/)


## How to test

Follow the [How to Test](https://github.com/ourjapanlife/findadoc-server/blob/main/README.md) steps in the README and use the example queries below in GraphQL studio.

### Operation

```
mutation Mutation($input: HealthcareProfessionalInput) {
  createHealthcareProfessional(input: $input) {
    id
    acceptedInsuranceOptions
    degrees
    names {
      firstName
      lastName
      locale
    }
    specialties {
      id
      names {
        locale
        name
      }
    }
    spokenLanguages
  }
}
```

### Variables

```
{
  "input": {
    "acceptedInsuranceOptions": ["EMPLOYER_HEALTH_INSURANCE"],
    "degrees": "DOCTOR_OF_DENTAL_SURGERY",
    "names": [
      {
        "firstName": "some first name",
        "lastName": "some last name",
        "locale": "en"
      }
    ],
    "specialties": [
      {
        "names": [
          {
            "name": "some specialty",
            "locale": "en"
          }
        ]
      }
    ],
    "spokenLanguages": ["ENGLISH", "JAPANESE"]
  }
}
```