### PR TITLE
Connect DB and GraphQL in spoken languages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,7 +65,7 @@ module.exports = {
         'arrow-spacing': 'error',
         'block-spacing': ['error', 'always'],
         'brace-style': ['error', '1tbs', { allowSingleLine: true }],
-        camelcase: 'error',
+        camelcase: ['error', {allow: ['639_3']}],
         'comma-dangle': ['error', 'never'],
         'comma-spacing': ['error', { before: false, after: true }],
         'comma-style': 'error',

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ yarn install
 yarn prepare
 ```
 
+3. Init Prisma 💠
+```sh
+yarn prisma generate
+```
+
 ### Database Setup 🐘
 
 For simplicity we provide a dockerized postgres. As a prerequisite, you will need to install 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-json": "^3.1.0",
     "husky": "^8.0.1",
-    "prisma": "^4.8.0",
+    "prisma": "^4.8.1",
     "ts-mocha": "^10.0.0",
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.7.3"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "typescript": "^4.7.3"
   },
   "dependencies": {
-    "@prisma/client": "4.8.0",
+    "@prisma/client": "4.8.1",
     "apollo-server": "^3.8.2",
     "chai": "^4.3.6",
     "csv-parse": "^5.3.3",

--- a/prisma/devSetup.ts
+++ b/prisma/devSetup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 /* eslint-disable func-names */
 /* eslint-disable no-console */
 import { PrismaClient } from '@prisma/client';

--- a/prisma/migrations/20230109085948_spoken_languages/migration.sql
+++ b/prisma/migrations/20230109085948_spoken_languages/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `nameNative` to the `SpokenLanguage` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "SpokenLanguage" ADD COLUMN     "nameNative" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider = "prisma-client-js"
+  provider      = "prisma-client-js"
+  binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -48,9 +48,10 @@ model LocaleName {
 
 // Represents a language spoken by a healthcare provider
 model SpokenLanguage {
-  iso639_3 String @id
-  nameJa   String
-  nameEn   String
+  iso639_3   String @id
+  nameJa     String
+  nameEn     String
+  nameNative String
 
   healthcareProfessionals HealthcareProfessionalSpokenLanguage[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-arm64-openssl-3.0.x"]
+  binaryTargets = ["native", "linux-arm64-openssl-3.0.x", "linux-musl"]
 }
 
 datasource db {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-/* eslint-disable no-plusplus */
 /* eslint-disable no-console */
 // Seed data for the database
 // https://www.prisma.io/docs/guides/database/seed-database

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -12,6 +12,7 @@ const prisma = new PrismaClient();
 async function seedSpokenLanguages(verbose = false) {
     const iso639Col = 0;
     const enCol = 1;
+    const nativeCol = 2;
     const jaCol = 3;
 
     const spokenLanguages:string[][] = loadCSVFromFile('./prisma/seedData/spokenLanguages.csv');
@@ -23,7 +24,8 @@ async function seedSpokenLanguages(verbose = false) {
             create: {
                 iso639_3: language[iso639Col],
                 nameEn: language[enCol],
-                nameJa: language[jaCol]
+                nameJa: language[jaCol],
+                nameNative: language[nativeCol]
             }
         });
 

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -1,0 +1,7 @@
+// Re-use a single PrismaClient to avoid too many DB Connections
+// https://www.prisma.io/docs/guides/performance-and-optimization/connection-management 
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export default prisma;

--- a/src/mockData/mockData.ts
+++ b/src/mockData/mockData.ts
@@ -4,12 +4,10 @@ import {
     Degree,
     Facility,
     Insurance,
-    Language,
+    SpokenLanguage,
     HealthcareProfessional,
     Specialty
 } from '../typeDefs/gqlTypes';
-
-// language is the spoken language
 
 const facilities: Array<Facility> = [
     {
@@ -48,7 +46,7 @@ const facilities: Array<Facility> = [
                     }
                 ],
                 degrees: [<Degree>'DOCTOR_OF_MEDICINE'],
-                spokenLanguages: [<Language>'JAPANESE', <Language>'ENGLISH'],
+                spokenLanguages: [],
                 specialties:
           [
               {
@@ -86,7 +84,7 @@ const healthcareProfessionals: Array<HealthcareProfessional> = [
             }
         ],
         degrees: [<Degree>'DOCTOR_OF_PHILOSOPHY'],
-        spokenLanguages: [<Language>'JAPANESE', <Language>'ENGLISH'],
+        spokenLanguages: [],
         specialties: [
             {
                 id: '1',
@@ -114,7 +112,7 @@ const healthcareProfessionals: Array<HealthcareProfessional> = [
             }
         ],
         degrees: [<Degree>'DOCTOR_OF_PHILOSOPHY'],
-        spokenLanguages: [<Language>'JAPANESE'],
+        spokenLanguages: [],
         specialties: [
             {
                 id: '2',
@@ -142,7 +140,7 @@ const healthcareProfessionals: Array<HealthcareProfessional> = [
             }
         ],
         degrees: [<Degree>'DOCTOR_OF_PHILOSOPHY'],
-        spokenLanguages: [<Language>'ENGLISH'],
+        spokenLanguages: [],
         specialties: [
             {
                 id: '3',

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -7,11 +7,11 @@ import {
     Degree,
     Facility,
     Insurance,
-    Language,
     HealthcareProfessional,
     Specialty,
     PersonNameInput,
-    HealthcareProfessionalInput
+    HealthcareProfessionalInput,
+    SpokenLanguage
 } from './typeDefs/gqlTypes';
 
 const resolvers = {
@@ -59,7 +59,7 @@ const resolvers = {
       id: string,
       names: Array<PersonNameInput>,
       degrees: Array<Degree>,
-      spokenLanguages: Array<Language>,
+      spokenLanguages: Array<SpokenLanguage>,
       specialties: Array<Specialty>,
       acceptedInsuranceOptions: Array<Insurance>
     }) => {

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import { getFacilityById, getFacilities } from './services/facilityService';
 import { getHealthcareProfessionalById, getHealthcareProfessionals } from './services/healthcareProfessionalService';
 import { getSpecialtyById, getSpecialties } from './services/specialtyService';
-import { getSpokenLanguages } from './services/spokenLanguageService';
+import { getSpokenLanguageByIso, getSpokenLanguages } from './services/spokenLanguageService';
 import {
     Degree,
     Facility,
@@ -52,7 +52,8 @@ const resolvers = {
 
             return matchingSpecialty;
         },
-        spokenLanguages: () => getSpokenLanguages()
+        spokenLanguages: () => getSpokenLanguages(),
+        spokenLanguage: (_parent: SpokenLanguage, args: {iso639_3: string;}) => getSpokenLanguageByIso(args.iso639_3)
     },
     Mutation: {
         createHealthcareProfessional: (_parent: HealthcareProfessionalInput, args: {

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto';
 import { getFacilityById, getFacilities } from './services/facilityService';
 import { getHealthcareProfessionalById, getHealthcareProfessionals } from './services/healthcareProfessionalService';
 import { getSpecialtyById, getSpecialties } from './services/specialtyService';
+import { getSpokenLanguages } from './services/spokenLanguageService';
 import {
     Degree,
     Facility,
@@ -50,7 +51,8 @@ const resolvers = {
             const matchingSpecialty = getSpecialtyById(args.id);
 
             return matchingSpecialty;
-        }
+        },
+        spokenLanguages: () => getSpokenLanguages()
     },
     Mutation: {
         createHealthcareProfessional: (_parent: HealthcareProfessionalInput, args: {

--- a/src/services/spokenLanguageService.ts
+++ b/src/services/spokenLanguageService.ts
@@ -1,12 +1,20 @@
 
 import { SpokenLanguage } from '../typeDefs/gqlTypes';
-import { PrismaClient } from '@prisma/client';
-
-const prisma = new PrismaClient();
+import prisma from '../db/client';
 
 export const getSpokenLanguages = async () => {
-    const res = await prisma.spokenLanguage.findMany();
+    const languages = await prisma.spokenLanguage.findMany();
 
-    return res as Array<SpokenLanguage>;
+    return languages as Array<SpokenLanguage>;
+};
+
+export const getSpokenLanguageByIso = async (iso639_3: string) => {
+    const found = await prisma.spokenLanguage.findFirst({
+        where: {
+            iso639_3
+        }
+    });
+
+    return found as SpokenLanguage;
 };
 

--- a/src/services/spokenLanguageService.ts
+++ b/src/services/spokenLanguageService.ts
@@ -1,0 +1,12 @@
+
+import { SpokenLanguage } from '../typeDefs/gqlTypes';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+
+export const getSpokenLanguages = async () => {
+    const res = await prisma.spokenLanguage.findMany();
+
+    return res as Array<SpokenLanguage>;
+};
+

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -20,7 +20,7 @@ type FacilityName {
 input HealthcareProfessionalInput {
   names: [PersonNameInput]!
   degrees: [Degree]!
-  spokenLanguages: [Language]!
+  spokenLanguages: [SpokenLanguageInput]!
   specialties: [SpecialtyInput]!
   acceptedInsuranceOptions: [Insurance]!
 }
@@ -29,7 +29,7 @@ type HealthcareProfessional {
   id: ID!
   names: [PersonName]!
   degrees: [Degree]!
-  spokenLanguages: [Language]!
+  spokenLanguages: [SpokenLanguage]!
   specialties: [Specialty]!
   acceptedInsuranceOptions: [Insurance]!
 }
@@ -67,6 +67,17 @@ type SpecialtyName {
   locale: String!
 }
 
+input SpokenLanguageInput {
+  iso639_3: String!
+}
+
+type SpokenLanguage {
+  iso639_3: String!
+  nameJa:   String!
+  nameEn:   String!
+  nameNative: String!
+}
+
 enum Degree {
   DOCTOR_OF_MEDICINE
   DOCTOR_OF_PHILOSOPHY
@@ -81,18 +92,6 @@ enum Insurance {
   INTERNATIONAL_HEALTH_INSURANCE
   NO_INSURANCE
   UNKNOWN
-}
-
-type SpokenLanguage {
-  iso639_3: String!
-  nameJa:   String!
-  nameEn:   String!
-  nameNative: String!
-}
-
-enum Language {
-  ENGLISH
-  JAPANESE
 }
 
 type Query {

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -102,6 +102,7 @@ type Query {
   specialties: [Specialty]
   specialty(id: ID!): Specialty
   spokenLanguages: [SpokenLanguage]
+  spokenLanguage(iso639_3: String!): SpokenLanguage
 }
 
 type Mutation {

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -68,7 +68,10 @@ type SpecialtyName {
 }
 
 input SpokenLanguageInput {
-  iso639_3: String!
+  iso639_3: String!  
+  nameJa:   String!
+  nameEn:   String!
+  nameNative: String!
 }
 
 type SpokenLanguage {

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -87,6 +87,7 @@ type SpokenLanguage {
   iso639_3: String!
   nameJa:   String!
   nameEn:   String!
+  nameNative: String!
 }
 
 enum Language {

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -83,6 +83,12 @@ enum Insurance {
   UNKNOWN
 }
 
+type SpokenLanguage {
+  iso639_3: String!
+  nameJa:   String!
+  nameEn:   String!
+}
+
 enum Language {
   ENGLISH
   JAPANESE
@@ -95,6 +101,7 @@ type Query {
   healthcareProfessional(id: ID!): HealthcareProfessional
   specialties: [Specialty]
   specialty(id: ID!): Specialty
+  spokenLanguages: [SpokenLanguage]
 }
 
 type Mutation {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1878,10 +1878,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/engines@npm:4.8.0":
-  version: 4.8.0
-  resolution: "@prisma/engines@npm:4.8.0"
-  checksum: 5c1198905d7bf850c02cd59f244055003fc2a03ce99e715a0a872f568fb024aa4b347804829c8630964ff41b64cf8fa3e08c8cd2a444ad29c215c4b1dd9701b0
+"@prisma/engines@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@prisma/engines@npm:4.8.1"
+  checksum: 7ddddf5dcecbf2dd74e061fcf60c4ceef8a1c18e55aec3773ebcefb0edf0f8cf3b3e62eb7ad46fb82a85546ace5c626e1cc29b5d600ddf51989c8f07140600ca
   languageName: node
   linkType: hard
 
@@ -4487,7 +4487,7 @@ __metadata:
     graphql-import-node: ^0.0.5
     husky: ^8.0.1
     mocha: ^10.0.0
-    prisma: ^4.8.0
+    prisma: ^4.8.1
     supertest: ^6.3.0
     ts-mocha: ^10.0.0
     ts-node: ^10.9.1
@@ -6624,15 +6624,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prisma@npm:^4.8.0":
-  version: 4.8.0
-  resolution: "prisma@npm:4.8.0"
+"prisma@npm:^4.8.1":
+  version: 4.8.1
+  resolution: "prisma@npm:4.8.1"
   dependencies:
-    "@prisma/engines": 4.8.0
+    "@prisma/engines": 4.8.1
   bin:
     prisma: build/index.js
     prisma2: build/index.js
-  checksum: 22ebaa32c51fb2938626d742d9ae68be5ad49a44dad2046bfe40439a64d06e8f84d4915f66100554d7840c3c5228c6b5c4216d9f5a698d5dd11a46ab528654cf
+  checksum: 6f09e9add231c1f38cc01051037c0abb5ff4db6773d5543ce8917beee76b15351474e97b0c06eaa25267f0a65e7596a8428292317c53d1868e9aaa09cd6e0705
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1857,9 +1857,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@prisma/client@npm:4.8.0":
-  version: 4.8.0
-  resolution: "@prisma/client@npm:4.8.0"
+"@prisma/client@npm:4.8.1":
+  version: 4.8.1
+  resolution: "@prisma/client@npm:4.8.1"
   dependencies:
     "@prisma/engines-version": 4.8.0-61.d6e67a83f971b175a593ccc12e15c4a757f93ffe
   peerDependencies:
@@ -1867,7 +1867,7 @@ __metadata:
   peerDependenciesMeta:
     prisma:
       optional: true
-  checksum: c0256721bd4e07fb1fdf4d0857489379769af1eaac0aec79387e32092e63e1246a95fef634f6c07bf1bdddc7c11f3e073c78e5c92b9a708f559773a3f656f94a
+  checksum: 93dc263e56f473478c8b7e051b7bad09893eac4fe0e2ba93af56e8394fb21e7e23a8fff0fde39f4aaaf85c3bfb0b51f3f50cc1cab3a585fdb94687f08e1c385a
   languageName: node
   linkType: hard
 
@@ -4468,7 +4468,7 @@ __metadata:
     "@graphql-codegen/cli": ^2.16.2
     "@graphql-codegen/typescript": ^2.7.3
     "@graphql-codegen/typescript-resolvers": ^2.7.3
-    "@prisma/client": 4.8.0
+    "@prisma/client": 4.8.1
     "@types/chai": ^4.3.3
     "@types/expect": ^24.3.0
     "@types/mocha": ^10.0.0


### PR DESCRIPTION
Part of #87 and resolves #45

# What changed
- [x] Add SpokenLanguages graphQL query
- [x] connect to Prisma
- [x] fix DB model to include native language
- [x] Remove "language" enum from GraphQL
- [x] Query a single by iso code

# Testing instructions

## Select Many
Run the following in Apollo Sandbox:
```
query Query {
  spokenLanguages {
    iso639_3
    nameEn
    nameJa
    nativeName
  }
}
```

## Select one
Run the backend then click the following to fill the query

https://studio.apollographql.com/sandbox/explorer?endpoint=http%3A%2F%2Flocalhost%3A3001%2F&explorerURLState=N4IgzghgbgpgJgYQPYBsUwMYBcCWSB2AknCAFwgwQBGcGA7DDALQBsEAHAGZMAsdEzKuwCszAAwAmKgGYe0sTwh0JEkABpw0eMjSZcBAKL4sAJwCexMiACM9aROlUWTKhjjte1uh44SAnEzs7BCy0hgS7HCc0iAAvkA&referrer=operation_collections

Test cases for iso code: 'spa' should retrieve spanish, 'eng' english, 'xxx' null