### PR TITLE
fix: set platform version to make prisma compatible with M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,15 +53,14 @@ Edit the .env file and set the database password
 docker compose up
 ```
 
-3. Run the migrations
-```sh
-yarn prisma migrate dev
-```
+### Database and ORM commands
 
-4. Run the seeds
-```sh
-yarn prisma db seed
-```
+Re-run migrations with `yarn prisma migrate dev`
+
+Create a new migration by:
+1. Editing schema.prisma and save
+2. Run `yarn prisma migrate  dev --name snake_case_title`
+3. Before running the backend, regenerate the Prisma Client with `yarn prisma generate`
 
 ### Note about migration files
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,16 @@ Edit the .env file and set the database password
 docker compose up
 ```
 
+3. Run the migrations
+```sh
+yarn prisma migrate dev
+```
+
+4. Run the seeds
+```sh
+yarn prisma db seed
+```
+
 ### Note about migration files
 
 Migration files should never edited after merging to `main` in order to keep an accurate database history. If you want

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     working_dir: /target
     volumes:
       - .:/target
-    command: "yarn install"
+    command: "yarn install; yarn prisma generate"
   migrate:
     depends_on:
       - db-configure

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: '3.8'
 services:
   db:
     image: postgres:14-alpine
@@ -11,11 +11,7 @@ services:
     ports:
       - ${POSTGRES_PORT}:${DOCKER_INTERNAL_PORT}
     healthcheck:
-      test:
-        [
-          "CMD",
-          "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"
-        ]
+      test: ['CMD', 'pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}']
       interval: 10s
       timeout: 3s
       retries: 5
@@ -43,13 +39,13 @@ services:
       - db-configure
     env_file:
       - .env
-    image: node:18.12.1-alpine
+    image: node:18.12.1
     networks:
       - new
     working_dir: /target
     volumes:
       - .:/target
-    command: "yarn install; yarn prisma generate"
+    command: 'yarn install; yarn prisma generate'
   migrate:
     depends_on:
       - db-configure
@@ -63,7 +59,7 @@ services:
       - db
     networks:
       - new
-    image: node:18.12.1-alpine
+    image: node:18.12.1
     working_dir: /target
     volumes:
       - .:/target
@@ -73,7 +69,6 @@ services:
 volumes:
   pgdata:
   status:
-
 
 networks:
   new:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,8 @@ services:
       - db-configure
     env_file:
       - .env
-    image: node:18.12.1
+    platform: linux/amd64
+    image: node:18.12.1-alpine
     networks:
       - new
     working_dir: /target
@@ -59,7 +60,8 @@ services:
       - db
     networks:
       - new
-    image: node:18.12.1
+    image: node:18.12.1-alpine
+    platform: linux/amd64
     working_dir: /target
     volumes:
       - .:/target

--- a/docker/db-init.sh
+++ b/docker/db-init.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 echo "😃😃😃😃😃😃 DB SETUP TIME 😃😃😃😃😃"
 
 echo $POSTGRES_DB
-uname -a
 
 
 until PGPASSWORD=$POSTGRES_PASSWORD psql -h ${DOCKER_POSTGRES_HOST} -U $POSTGRES_USER -p $DOCKER_INTERNAL_PORT -c '\q'; do

--- a/docker/db-init.sh
+++ b/docker/db-init.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 echo "😃😃😃😃😃😃 DB SETUP TIME 😃😃😃😃😃"
 
 echo $POSTGRES_DB
+uname -a
 
 
 until PGPASSWORD=$POSTGRES_PASSWORD psql -h ${DOCKER_POSTGRES_HOST} -U $POSTGRES_USER -p $DOCKER_INTERNAL_PORT -c '\q'; do

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "darwin-arm64", "linux-arm64-openssl-3.0.x", "linux-musl"]
+  binaryTargets = ["native"]
 }
 
 datasource db {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "linux-arm64-openssl-3.0.x", "linux-musl"]
+  binaryTargets = ["native", "darwin-arm64", "linux-arm64-openssl-3.0.x", "linux-musl"]
 }
 
 datasource db {


### PR DESCRIPTION
Resolves #90 


# What changed
1. Adds `platform: linux/amd64` to the Docker build.
2. Updates the README steps for getting the database running

# Testing instructions
1. Follow the updated steps in the README to get the database and docker running.
2. Do the following query in GraphQL studio:

Operation:
```
query Query($iso6393: String!) {
  spokenLanguage(iso639_3: $iso6393) {
    nameNative
    nameJa
    nameEn
    iso639_3
  }
}
```

Variables
```
{
  "iso6393": "eng"
}
```

### Screenshot
<img width="1436" alt="Screenshot 2023-01-13 at 9 06 41 AM" src="https://user-images.githubusercontent.com/31802656/212206994-01b3953a-f848-4615-92b1-68767876fb4c.png">

