### PR TITLE
avoid DB conflicts

### DIFF
--- a/prisma/devSetup.ts
+++ b/prisma/devSetup.ts
@@ -65,6 +65,8 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
         });
 
         // Link spoken languages
+        // Note: I didn't bother to unlink languages in this setup. 
+        // If making major changes to the seed data, better to drop and recreate the database
         const spokenLangList = row[spokenLangCol].split(',');
 
         spokenLangList.forEach(async lang => {
@@ -77,19 +79,28 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
             );
 
             if (dbSpokenLang) {
-                // TODO change to upsert
-                await prisma.healthcareProfessionalSpokenLanguage.create(
+                // Check if it's already linked to the provider
+                const found = await prisma.healthcareProfessionalSpokenLanguage.findFirst(
                     {
-                        data: {
-                            spokenLanguageIso639_3: dbSpokenLang.iso639_3,
-                            healthcareProfessionalId: newHealthPro.id
-                        }
+                        where: {healthcareProfessionalId: newHealthPro.id, 
+                            spokenLanguageIso639_3: dbSpokenLang.iso639_3}
                     }
                 );
+
+                if (!found) {
+                    await prisma.healthcareProfessionalSpokenLanguage.create(
+                        {
+                            data: {spokenLanguageIso639_3: dbSpokenLang.iso639_3,
+                                healthcareProfessionalId: newHealthPro.id}
+                        }
+                    );
+                }
             }
         });
 
         // Link Degrees
+        // Note: I didn't bother to unlink degrees in this setup. 
+        // If making major changes to the seed data, better to drop and recreate the database
         const degreeList = row[degreeCol].split(',');
 
         degreeList.forEach(async degree => {
@@ -102,20 +113,31 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
             );
 
             if (dbDegree) {
-                // TODO change to upsert
-                await prisma.healthcareProfessionalDegree.create(
+                // Check if it's already linked to the provider
+                const found = await prisma.healthcareProfessionalDegree.findFirst(
                     {
-                        data: {
-                            degreeId: dbDegree.id,
-                            healthcareProfessionalId: newHealthPro.id
-                        }
+                        where: {healthcareProfessionalId: newHealthPro.id, 
+                            degreeId: dbDegree.id}
                     }
                 );
+
+                if (!found) {
+                    await prisma.healthcareProfessionalDegree.create(
+                        {
+                            data: {
+                                degreeId: dbDegree.id,
+                                healthcareProfessionalId: newHealthPro.id
+                            }
+                        }
+                    );
+                }
                 console.log(dbDegree);
             }
         });
 
         // Link Specialties
+        // Note: I didn't bother to unlink specialties in this setup. 
+        // If making major changes to the seed data, better to drop and recreate the database
         const specialtyList = row[specialtyCol].split(',');
 
         specialtyList.forEach(async specialty => {
@@ -127,14 +149,24 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
             });
 
             if (dbSpecialty) {
-                await prisma.healthcareProfessionalSpecialty.create(
+                // Check if it's already linked to the provider
+                const found = await prisma.healthcareProfessionalSpecialty.findFirst(
                     {
-                        data: {
-                            specialtyId: dbSpecialty.id,
-                            healthcareProfessionalId: newHealthPro.id
-                        }
+                        where: {healthcareProfessionalId: newHealthPro.id, 
+                            specialtyId: dbSpecialty.id}
                     }
                 );
+                
+                if (!found) {
+                    await prisma.healthcareProfessionalSpecialty.create(
+                        {
+                            data: {
+                                specialtyId: dbSpecialty.id,
+                                healthcareProfessionalId: newHealthPro.id
+                            }
+                        }
+                    );
+                }
             }
         });
 


### PR DESCRIPTION
Resolves #94 


# What changed
- Ensure the seed file can be run more than once without getting ugly constraint errors and crashing the script

# Testing instructions

You should be able to run `docker compose up` multiple times in a row (not in parallel) without deleting the docker container. The containers should shut down gracefully like so:
```sh
...
findadoc-server-migrate-1       |   id: 13,
findadoc-server-migrate-1       |   nameJa: '何',
findadoc-server-migrate-1       |   nameEn: 'Physician Assistant / Associate',
findadoc-server-migrate-1       |   abbreviation: 'PA'
findadoc-server-migrate-1       | }
findadoc-server-migrate-1       | { id: 5, nameJa: '医師', nameEn: 'Medical Doctor', abbreviation: 'MD' }
findadoc-server-migrate-1       |
findadoc-server-migrate-1       | 🌱  The seed command has been executed.
findadoc-server-migrate-1 exited with code 0
```
