### PR TITLE
add editor config and adjust indentation to 4

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+# Matches multiple files with brace expansion notation
+[*.{js,ts,json}]
+charset = utf-8
+
+[*.graphql]
+charset = utf-8
+indent_size = 2
+
+[*.yml]
+charset = utf-8
+indent_size = 2
+
+[*.prisma]
+charset = utf-8
+
+[*.sh]
+charset = utf-8
+
+[*.csv]
+charset = utf-8
+insert_final_newline = false

--- a/package.json
+++ b/package.json
@@ -1,64 +1,64 @@
 {
-  "name": "findadoc-server",
-  "version": "1.0.0",
-  "description": "Backend for Find a Doc, Japan",
-  "main": "index.js",
-  "scripts": {
-    "prepare": "husky install",
-    "test": "ts-mocha src/tests/**.ts",
-    "dev": "yarn && ts-node-dev --transpile-only --no-notify --exit-child src/index.ts",
-    "generate": "yarn && graphql-codegen --config ./src/typesgeneratorconfig.ts",
-    "lint": "eslint . --ext .js,.ts,.json",
-    "lint:check": "eslint . --ext .js,.ts,.json",
-    "lint:ci": "eslint . --ext .js,.ts,.json",
-    "migrate": "prisma migrate dev"
-  },
-  "prisma": {
-    "seed": "ts-node prisma/seed.ts"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/ourjapanlife/findadoc-server.git"
-  },
-  "keywords": [],
-  "author": "Find a Doc, Japan",
-  "license": "UNLICENSED",
-  "private": true,
-  "bugs": {
-    "url": "https://github.com/ourjapanlife/findadoc-server/issues"
-  },
-  "homepage": "https://github.com/ourjapanlife/findadoc-server#readme",
-  "devDependencies": {
-    "@graphql-codegen/cli": "^2.16.2",
-    "@graphql-codegen/typescript": "^2.7.3",
-    "@graphql-codegen/typescript-resolvers": "^2.7.3",
-    "@types/chai": "^4.3.3",
-    "@types/expect": "^24.3.0",
-    "@types/mocha": "^10.0.0",
-    "@types/supertest": "^2.0.12",
-    "@typescript-eslint/eslint-plugin": "^5.30.7",
-    "@typescript-eslint/parser": "^5.31.0",
-    "eslint": "^8.20.0",
-    "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-airbnb-typescript": "^17.0.0",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-json": "^3.1.0",
-    "husky": "^8.0.1",
-    "prisma": "^4.8.1",
-    "ts-mocha": "^10.0.0",
-    "ts-node-dev": "^2.0.0",
-    "typescript": "^4.7.3"
-  },
-  "dependencies": {
-    "@prisma/client": "4.8.1",
-    "apollo-server": "^3.8.2",
-    "chai": "^4.3.6",
-    "csv-parse": "^5.3.3",
-    "graphql": "^16.5.0",
-    "graphql-import-node": "^0.0.5",
-    "mocha": "^10.0.0",
-    "supertest": "^6.3.0",
-    "ts-node": "^10.9.1"
-  },
-  "packageManager": "yarn@3.2.4"
+    "name": "findadoc-server",
+    "version": "1.0.0",
+    "description": "Backend for Find a Doc, Japan",
+    "main": "index.js",
+    "scripts": {
+        "prepare": "husky install",
+        "test": "ts-mocha src/tests/**.ts",
+        "dev": "yarn && ts-node-dev --transpile-only --no-notify --exit-child src/index.ts",
+        "generate": "yarn && graphql-codegen --config ./src/typesgeneratorconfig.ts",
+        "lint": "eslint . --ext .js,.ts,.json",
+        "lint:check": "eslint . --ext .js,.ts,.json",
+        "lint:ci": "eslint . --ext .js,.ts,.json",
+        "migrate": "prisma migrate dev"
+    },
+    "prisma": {
+        "seed": "ts-node prisma/seed.ts"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/ourjapanlife/findadoc-server.git"
+    },
+    "keywords": [],
+    "author": "Find a Doc, Japan",
+    "license": "UNLICENSED",
+    "private": true,
+    "bugs": {
+        "url": "https://github.com/ourjapanlife/findadoc-server/issues"
+    },
+    "homepage": "https://github.com/ourjapanlife/findadoc-server#readme",
+    "devDependencies": {
+        "@graphql-codegen/cli": "^2.16.2",
+        "@graphql-codegen/typescript": "^2.7.3",
+        "@graphql-codegen/typescript-resolvers": "^2.7.3",
+        "@types/chai": "^4.3.3",
+        "@types/expect": "^24.3.0",
+        "@types/mocha": "^10.0.0",
+        "@types/supertest": "^2.0.12",
+        "@typescript-eslint/eslint-plugin": "^5.30.7",
+        "@typescript-eslint/parser": "^5.31.0",
+        "eslint": "^8.20.0",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-airbnb-typescript": "^17.0.0",
+        "eslint-plugin-import": "^2.26.0",
+        "eslint-plugin-json": "^3.1.0",
+        "husky": "^8.0.1",
+        "prisma": "^4.8.1",
+        "ts-mocha": "^10.0.0",
+        "ts-node-dev": "^2.0.0",
+        "typescript": "^4.7.3"
+    },
+    "dependencies": {
+        "@prisma/client": "4.8.1",
+        "apollo-server": "^3.8.2",
+        "chai": "^4.3.6",
+        "csv-parse": "^5.3.3",
+        "graphql": "^16.5.0",
+        "graphql-import-node": "^0.0.5",
+        "mocha": "^10.0.0",
+        "supertest": "^6.3.0",
+        "ts-node": "^10.9.1"
+    },
+    "packageManager": "yarn@3.2.4"
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,25 +2,25 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-  provider      = "prisma-client-js"
-  binaryTargets = ["native"]
+    provider      = "prisma-client-js"
+    binaryTargets = ["native"]
 }
 
 datasource db {
-  provider          = "postgresql"
-  url               = env("DATABASE_URL")
-  shadowDatabaseUrl = env("SHADOW_DB_URL")
+    provider          = "postgresql"
+    url               = env("DATABASE_URL")
+    shadowDatabaseUrl = env("SHADOW_DB_URL")
 }
 
 // Represents the name of a human individual in both Japanese and Romanji characters.
 model PersonName {
-  id                     Int                     @id @default(autoincrement())
-  names                  LocaleName[]
-  HealthcareProfessional HealthcareProfessional?
+    id                     Int                     @id @default(autoincrement())
+    names                  LocaleName[]
+    HealthcareProfessional HealthcareProfessional?
 
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
-  deletedAt DateTime?
+    createdAt DateTime  @default(now())
+    updatedAt DateTime  @updatedAt
+    deletedAt DateTime?
 }
 
 // Represents a variant of a Person's name in a specific Locale
@@ -30,155 +30,155 @@ model PersonName {
 // ja: ジェーン・スミス
 // A person may only have one LocaleName per locale
 model LocaleName {
-  id         Int     @id @default(autoincrement())
-  locale     String // ISO-639-1
-  firstName  String
-  middleName String?
-  lastName   String
+    id         Int     @id @default(autoincrement())
+    locale     String // ISO-639-1
+    firstName  String
+    middleName String?
+    lastName   String
 
-  PersonName   PersonName? @relation(fields: [personNameId], references: [id])
-  personNameId Int?
+    PersonName   PersonName? @relation(fields: [personNameId], references: [id])
+    personNameId Int?
 
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  // no soft deletes due to unique constraint
+    createdAt DateTime @default(now())
+    updatedAt DateTime @updatedAt
+    // no soft deletes due to unique constraint
 
-  // only allow one localeName per PersonName
-  @@unique([locale, personNameId])
+    // only allow one localeName per PersonName
+    @@unique([locale, personNameId])
 }
 
 // Represents a language spoken by a healthcare provider
 model SpokenLanguage {
-  iso639_3   String @id
-  nameJa     String
-  nameEn     String
-  nameNative String
+    iso639_3   String @id
+    nameJa     String
+    nameEn     String
+    nameNative String
 
-  healthcareProfessionals HealthcareProfessionalSpokenLanguage[]
+    healthcareProfessionals HealthcareProfessionalSpokenLanguage[]
 }
 
 // Represents the area a professional works in, such as Gynecology, gastroenterology, oncology, physical therapy, etc.
 model Specialty {
-  id     Int    @id @default(autoincrement())
-  nameJa String
-  nameEn String
+    id     Int    @id @default(autoincrement())
+    nameJa String
+    nameEn String
 
-  HealthcareProfessionalSpecialty HealthcareProfessionalSpecialty[]
+    HealthcareProfessionalSpecialty HealthcareProfessionalSpecialty[]
 }
 
 // Denotes health-related degrees, such as M.D., Ph.D, D.D.S., D.O, etc.
 model Degree {
-  id           Int    @id @default(autoincrement())
-  nameJa       String
-  nameEn       String
-  abbreviation String
+    id           Int    @id @default(autoincrement())
+    nameJa       String
+    nameEn       String
+    abbreviation String
 
-  HealthcareProfessionalDegree HealthcareProfessionalDegree[]
+    HealthcareProfessionalDegree HealthcareProfessionalDegree[]
 }
 
 // Reperesents a healthcare professional such as a doctor, nurse, therapist, etc.
 model HealthcareProfessional {
-  id           Int        @id @default(autoincrement())
-  name         PersonName @relation(fields: [personNameId], references: [id])
-  personNameId Int        @unique
+    id           Int        @id @default(autoincrement())
+    name         PersonName @relation(fields: [personNameId], references: [id])
+    personNameId Int        @unique
 
-  // many to many relations
-  HealthcareProfessionalSpecialty HealthcareProfessionalSpecialty[]
-  HealthcareProfessionalDegree    HealthcareProfessionalDegree[]
-  spokenLanguages                 HealthcareProfessionalSpokenLanguage[]
+    // many to many relations
+    HealthcareProfessionalSpecialty HealthcareProfessionalSpecialty[]
+    HealthcareProfessionalDegree    HealthcareProfessionalDegree[]
+    spokenLanguages                 HealthcareProfessionalSpokenLanguage[]
 
-  contact Contact? @relation(fields: [contactId], references: [id])
+    contact Contact? @relation(fields: [contactId], references: [id])
 
-  contactId Int?
+    contactId Int?
 
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  deletedAt   DateTime?
-  isPublished Boolean   @default(false)
+    createdAt   DateTime  @default(now())
+    updatedAt   DateTime  @updatedAt
+    deletedAt   DateTime?
+    isPublished Boolean   @default(false)
 }
 
 // Many to Many relation between HealthcareProfessional and Specialty
 model HealthcareProfessionalSpecialty {
-  HealthcareProfessional   HealthcareProfessional @relation(fields: [healthcareProfessionalId], references: [id])
-  healthcareProfessionalId Int
+    HealthcareProfessional   HealthcareProfessional @relation(fields: [healthcareProfessionalId], references: [id])
+    healthcareProfessionalId Int
 
-  Specialty   Specialty @relation(fields: [specialtyId], references: [id])
-  specialtyId Int
+    Specialty   Specialty @relation(fields: [specialtyId], references: [id])
+    specialtyId Int
 
-  @@id([healthcareProfessionalId, specialtyId])
+    @@id([healthcareProfessionalId, specialtyId])
 }
 
 // Many to Many relation between HealthcareProfessional and Degree
 model HealthcareProfessionalDegree {
-  HealthcareProfessional   HealthcareProfessional @relation(fields: [healthcareProfessionalId], references: [id])
-  healthcareProfessionalId Int
+    HealthcareProfessional   HealthcareProfessional @relation(fields: [healthcareProfessionalId], references: [id])
+    healthcareProfessionalId Int
 
-  Degree   Degree @relation(fields: [degreeId], references: [id])
-  degreeId Int
+    Degree   Degree @relation(fields: [degreeId], references: [id])
+    degreeId Int
 
-  @@id([healthcareProfessionalId, degreeId])
+    @@id([healthcareProfessionalId, degreeId])
 }
 
 // Many to Many relation between HealthcareProfessional and SpokenLanguage
 model HealthcareProfessionalSpokenLanguage {
-  HealthcareProfessional   HealthcareProfessional @relation(fields: [healthcareProfessionalId], references: [id])
-  healthcareProfessionalId Int
+    HealthcareProfessional   HealthcareProfessional @relation(fields: [healthcareProfessionalId], references: [id])
+    healthcareProfessionalId Int
 
-  SpokenLanguage         SpokenLanguage @relation(fields: [spokenLanguageIso639_3], references: [iso639_3])
-  spokenLanguageIso639_3 String
+    SpokenLanguage         SpokenLanguage @relation(fields: [spokenLanguageIso639_3], references: [iso639_3])
+    spokenLanguageIso639_3 String
 
-  @@id([healthcareProfessionalId, spokenLanguageIso639_3])
+    @@id([healthcareProfessionalId, spokenLanguageIso639_3])
 }
 
 // Represents how to contact an Healthcare Professional or a Facility
 model Contact {
-  id       Int    @id @default(autoincrement())
-  email    String
-  phone    String
-  website  String
-  mapsLink String
+    id       Int    @id @default(autoincrement())
+    email    String
+    phone    String
+    website  String
+    mapsLink String
 
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
-  deletedAt DateTime?
+    createdAt DateTime  @default(now())
+    updatedAt DateTime  @updatedAt
+    deletedAt DateTime?
 
-  address                PhysicalAddress?         @relation(fields: [addressId], references: [id])
-  addressId              Int
-  Facility               Facility[]
-  HealthcareProfessional HealthcareProfessional[]
+    address                PhysicalAddress?         @relation(fields: [addressId], references: [id])
+    addressId              Int
+    Facility               Facility[]
+    HealthcareProfessional HealthcareProfessional[]
 }
 
 // A physical address represents a location on a map
 model PhysicalAddress {
-  id             Int     @id @default(autoincrement())
-  postalCode     String
-  prefectureEn   String
-  cityEn         String
-  addressLine1En String
-  addressLine2En String?
+    id             Int     @id @default(autoincrement())
+    postalCode     String
+    prefectureEn   String
+    cityEn         String
+    addressLine1En String
+    addressLine2En String?
 
-  prefectureJa   String?
-  cityJa         String?
-  addressLine1Ja String?
-  addressLine2Ja String?
+    prefectureJa   String?
+    cityJa         String?
+    addressLine1Ja String?
+    addressLine2Ja String?
 
-  createdAt DateTime  @default(now())
-  updatedAt DateTime  @updatedAt
-  deletedAt DateTime?
+    createdAt DateTime  @default(now())
+    updatedAt DateTime  @updatedAt
+    deletedAt DateTime?
 
-  Contact Contact[]
+    Contact Contact[]
 }
 
 model Facility {
-  id     Int    @id @default(autoincrement())
-  nameEn String
-  nameJa String
+    id     Int    @id @default(autoincrement())
+    nameEn String
+    nameJa String
 
-  createdAt   DateTime  @default(now())
-  updatedAt   DateTime  @updatedAt
-  deletedAt   DateTime?
-  isPublished Boolean   @default(false)
+    createdAt   DateTime  @default(now())
+    updatedAt   DateTime  @updatedAt
+    deletedAt   DateTime?
+    isPublished Boolean   @default(false)
 
-  contact   Contact @relation(fields: [contactId], references: [id])
-  contactId Int
+    contact   Contact @relation(fields: [contactId], references: [id])
+    contactId Int
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,20 +1,20 @@
 {
-  "compilerOptions": {
-    "target": "ES2018",
-    "module": "commonjs",
-    "lib": [
-      "esnext"
+    "compilerOptions": {
+        "target": "ES2018",
+        "module": "commonjs",
+        "lib": [
+            "esnext"
+        ],
+        "strict": true,
+        "outDir": "dist",
+        "sourceMap": true,
+        "esModuleInterop": true
+    },
+    "include": [
+        "src",
+        "prisma"
     ],
-    "strict": true,
-    "outDir": "dist",
-    "sourceMap": true,
-    "esModuleInterop": true
-  },
-  "include": [
-    "src",
-    "prisma"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
+    "exclude": [
+        "node_modules"
+    ]
 }


### PR DESCRIPTION
Resolves #58 


# What changed
- Add editor config 
- Update indentation style to be 4 as much as possible
(we can adjust the graphql and yaml files later but I am worried about merge conflicts right now

# Testing instructions
EditorConfig works automatically with many tools: https://editorconfig.org/#pre-installed
If you have VS Code, you will need to install a plugin: https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig

Now when you edit files, you should automatically get the right indentation when you press tab, have the correct line endings `\n` (unix) not `CRLF` (windows). It can help us easily work with folks on different platforms. 

Thanks to @ermish for suggesting it