### PR TITLE
fix: replace forEach to fix race condition

### DIFF
--- a/prisma/devSetup.ts
+++ b/prisma/devSetup.ts
@@ -8,23 +8,6 @@ function parseAcceptedInsurance(input: string) {
 
     const insurances = Array<Insurance>()
 
-    // splitInput.forEach(acceptedInsurance => {
-    //     switch (acceptedInsurance) {
-    //         case 'jp': {
-    //             insurances.push(Insurance.JAPANESE_HEALTH_INSURANCE)
-    //             break
-    //         }
-    //         case 'int': {
-    //             insurances.push(Insurance.INTERNATIONAL_HEALTH_INSURANCE)
-    //             break
-    //         }
-    //         case 'none': {
-    //             insurances.push(Insurance.INSURANCE_NOT_ACCEPTED)
-    //             break
-    //         }
-    //     }
-    // })
-
     for (let i = 0; i < splitInput.length; i++) {
         switch (splitInput[i]) {
             case 'jp': {
@@ -59,7 +42,6 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
     const devData:string[][] = loadCSVFromFile('./prisma/seedData/devHealthcareProfessionals.csv')
     
     for (let index = 0; index < devData.length; index++) {
-    // devData.forEach(async (row: string[], index: number) => {
     // generate some unique ids using even/odd strategy
         const enID = 2 * index
         const jaID = 2 * index + 1
@@ -102,7 +84,6 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
 
         for (let i = 0; i < spokenLangList.length; i++) {
             const lang = spokenLangList[i]
-            // spokenLangList.forEach(async lang => {
             const dbSpokenLang = await prisma.spokenLanguage.findFirst(
                 {
                     where: {
@@ -138,7 +119,6 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
 
         for (let i = 0; i < degreeList.length; i++) {
             const degree = degreeList[i]
-            // degreeList.forEach(async degree => {
             const dbDegree = await prisma.degree.findFirst(
                 {
                     where: {
@@ -177,7 +157,6 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
 
         for (let i = 0; i < specialtyList.length; i++) {
             const specialty = specialtyList[i]
-            // specialtyList.forEach(async specialty => {
             // TODO change to upsert
             const dbSpecialtyName = await prisma.specialtyName.findFirst({
                 where: {
@@ -231,7 +210,6 @@ const seedFacilities = async function(prisma: PrismaClient, verbose = false) {
 
     for (let index = 0; index < devData.length; index++) {
         const row = devData[index]
-        // devData.forEach(async (row: string[], index: number) => {
 
         console.log(row)
 

--- a/prisma/devSetup.ts
+++ b/prisma/devSetup.ts
@@ -8,8 +8,25 @@ function parseAcceptedInsurance(input: string) {
 
     const insurances = Array<Insurance>()
 
-    splitInput.forEach(acceptedInsurance => {
-        switch (acceptedInsurance) {
+    // splitInput.forEach(acceptedInsurance => {
+    //     switch (acceptedInsurance) {
+    //         case 'jp': {
+    //             insurances.push(Insurance.JAPANESE_HEALTH_INSURANCE)
+    //             break
+    //         }
+    //         case 'int': {
+    //             insurances.push(Insurance.INTERNATIONAL_HEALTH_INSURANCE)
+    //             break
+    //         }
+    //         case 'none': {
+    //             insurances.push(Insurance.INSURANCE_NOT_ACCEPTED)
+    //             break
+    //         }
+    //     }
+    // })
+
+    for (let i = 0; i < splitInput.length; i++) {
+        switch (splitInput[i]) {
             case 'jp': {
                 insurances.push(Insurance.JAPANESE_HEALTH_INSURANCE)
                 break
@@ -23,8 +40,7 @@ function parseAcceptedInsurance(input: string) {
                 break
             }
         }
-    })
-
+    }
     return insurances
 }
 
@@ -41,11 +57,13 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
     const insuranceCol = 9
 
     const devData:string[][] = loadCSVFromFile('./prisma/seedData/devHealthcareProfessionals.csv')
-
-    devData.forEach(async (row: string[], index: number) => {
+    
+    for (let index = 0; index < devData.length; index++) {
+    // devData.forEach(async (row: string[], index: number) => {
     // generate some unique ids using even/odd strategy
         const enID = 2 * index
         const jaID = 2 * index + 1
+        const row = devData[index]
 
         // create a healthcare professional with a nested write
         const newHealthPro = await prisma.healthcareProfessional.upsert({
@@ -82,7 +100,9 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
         // If making major changes to the seed data, better to drop and recreate the database
         const spokenLangList = row[spokenLangCol].split(',')
 
-        spokenLangList.forEach(async lang => {
+        for (let i = 0; i < spokenLangList.length; i++) {
+            const lang = spokenLangList[i]
+            // spokenLangList.forEach(async lang => {
             const dbSpokenLang = await prisma.spokenLanguage.findFirst(
                 {
                     where: {
@@ -109,14 +129,16 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
                     )
                 }
             }
-        })
+        }
 
         // Link Degrees
         // Note: I didn't bother to unlink degrees in this setup. 
         // If making major changes to the seed data, better to drop and recreate the database
         const degreeList = row[degreeCol].split(',')
 
-        degreeList.forEach(async degree => {
+        for (let i = 0; i < degreeList.length; i++) {
+            const degree = degreeList[i]
+            // degreeList.forEach(async degree => {
             const dbDegree = await prisma.degree.findFirst(
                 {
                     where: {
@@ -146,14 +168,16 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
                 }
                 console.log(dbDegree)
             }
-        })
+        }
 
         // Link Specialties
         // Note: I didn't bother to unlink specialties in this setup. 
         // If making major changes to the seed data, better to drop and recreate the database
         const specialtyList = row[specialtyCol].split(',')
 
-        specialtyList.forEach(async specialty => {
+        for (let i = 0; i < specialtyList.length; i++) {
+            const specialty = specialtyList[i]
+            // specialtyList.forEach(async specialty => {
             // TODO change to upsert
             const dbSpecialtyName = await prisma.specialtyName.findFirst({
                 where: {
@@ -182,12 +206,12 @@ const seedHealthcareProfessionals = async function(prisma: PrismaClient, verbose
                     )
                 }
             }
-        })
+        }
 
         if (verbose) {
             console.log(`Inserted ${newHealthPro.id} into HealthcareProfessional`)
         }
-    })
+    }
 }
 
 const seedFacilities = async function(prisma: PrismaClient, verbose = false) {
@@ -205,7 +229,10 @@ const seedFacilities = async function(prisma: PrismaClient, verbose = false) {
 
     const devData:string[][] = loadCSVFromFile('./prisma/seedData/devFacilities.csv')
 
-    devData.forEach(async (row: string[], index: number) => {
+    for (let index = 0; index < devData.length; index++) {
+        const row = devData[index]
+        // devData.forEach(async (row: string[], index: number) => {
+
         console.log(row)
 
         const newAddress = await prisma.physicalAddress.upsert({
@@ -257,7 +284,7 @@ const seedFacilities = async function(prisma: PrismaClient, verbose = false) {
         if (verbose) {
             console.log(`Inserted ${newFacility.nameEn} into Facilities`)
         }
-    })
+    }
 }
 
 export default { seedFacilities, seedHealthcareProfessionals }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -15,23 +15,24 @@ async function seedSpokenLanguages(verbose = false) {
 
     const spokenLanguages:string[][] = loadCSVFromFile('./prisma/seedData/spokenLanguages.csv')
 
-    spokenLanguages.forEach(async (language: string[]) => {
+    for (let i = 0; i < spokenLanguages.length; i++) {
+        const spokenLanguage = spokenLanguages[i]
         const upserted = await prisma.spokenLanguage.upsert({
-            where: { iso639_3: language[iso639Col] },
+            where: { iso639_3: spokenLanguage[iso639Col] },
             update: {},
             create: {
-                iso639_3: language[iso639Col],
-                nameEn: language[enCol],
-                nameJa: language[jaCol],
-                nameNative: language[nativeCol]
+                iso639_3: spokenLanguage[iso639Col],
+                nameEn: spokenLanguage[enCol],
+                nameJa: spokenLanguage[jaCol],
+                nameNative: spokenLanguage[nativeCol]
             }
         })
-
+        
         if (verbose) {
             // eslint-disable-next-line no-console
             console.log(`Inserted ${upserted.nameEn} into SpokenLanguages`)
         }
-    })
+    }
 }
 
 async function seedSpecialties(verbose = false) {
@@ -40,9 +41,11 @@ async function seedSpecialties(verbose = false) {
 
     const specialties:string[][] = loadCSVFromFile('./prisma/seedData/specialties.csv')
 
-    specialties.forEach(async (specialty: string[], index) => {
+    for (let i = 0; i < specialties.length; i++) {
+        const specialty = specialties[i]
+        const id = i + 1
         const upserted = await prisma.specialty.upsert({
-            where: { id: index },
+            where: { id: id },
             update: {},
             create: {
                 names: {
@@ -53,11 +56,11 @@ async function seedSpecialties(verbose = false) {
                 }
             }
         })
-
+        
         if (verbose) {
             console.log(`Inserted ${upserted.id} into Specialties`)
         }
-    })
+    }
 }
 
 async function seedDegrees(verbose = false) {


### PR DESCRIPTION
Resolves #121 


# What changed
Changes the `forEach` in the seed functions to for loops, because we discovered a race condition in #116.

# Testing instructions
1. Run `docker compose up`
2. Run `yarn prisma studio`
3. Confirm that the seeds in Prisma Studio match those found in `specialties.csv` and `spokenLanguages.csv`
