### PR TITLE
test build commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "scripts": {
         "prepare": "husky install",
         "test": "ts-mocha src/tests/**.ts",
+        "build:digitalocean": "yarn install --production=false && yarn run build && rm -rf node_modules && yarn install --production --frozen-lockfile",
+        "build": "tsc",
         "dev": "yarn && ts-node-dev --transpile-only --no-notify --exit-child src/index.ts",
         "prod": "ts-node src/index.ts",
         "docker:build": "docker build . -f ./docker/server/Dockerfile -t findadoc/server",


### PR DESCRIPTION
Resolves #[Issue number]


# What changed

Not sure if will work but I'm attempting to fix the builds with the following script (set in digitalocean):

```shell
npm install --production=false && npm run build && rm -rf node_modules && yarn install && cp src/typeDefs/schema.graphql dist/src/typeDefs/.
```
I was trying to invoke the typescript compiler directly but I think we may have to run it through npm for it to work. This script essentially installs dev dependencies, runs the typescript compiler, removes the node_modules directory and reinstalls to ensure only the production dependencies are installed. Then it moves the schema file which is not added to the generated application. The run step of the app has been updated to run `node dist/src/index.js`. This seems to work locally so I am hoping it works in production too.

# Testing instructions
