### PR TITLE
feat: add Submission type and input

### DIFF
--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -92,6 +92,22 @@ type SpokenLanguage {
   nameNative: String!
 }
 
+type Submission {
+  id: ID!
+  submittedLink: String!
+  healthCareProfessionalName: String!
+  spokenLanguages: [SpokenLanguage]!
+  isUnderReview: Boolean!
+  isApproved: Boolean!
+  isRejected: Boolean!
+}
+
+input SubmissionInput {
+  submittedLink: String!
+  healthCareProfessionalName: String!
+  spokenLanguages: [SpokenLanguageInput]!
+}
+
 input DegreeInput {
   id: ID!
   nameJa: String!
@@ -125,6 +141,8 @@ type Query {
   specialty(id: ID!): Specialty
   spokenLanguages: [SpokenLanguage]
   spokenLanguage(iso639_3: String!): SpokenLanguage
+  submissions: [Submission]
+  submission(id: ID!): Submission
 }
 
 type Mutation {


### PR DESCRIPTION
The reason for this change is to allow users to submit incomplete information to be reviewed by moderators prior to being searchable on the website

Resolves #202 

# What changed
1. Added a `type` called `Submission` and an `input` called `SubmissionInput`.
2. Added `submissions` and `submission` to `type Query`.

# Testing instructions
1. Run `yarn dev` and navigate to `localhost:3001` to open the Apollo Server Playground.
3. In the left pane under Query, click the `+` next to `submission`, then `id: ID!`.
4. In the middle pane, under Variables, replace the value of `"submissionId": null` with an id, i.e. `"1"`, then click the blue Submission button.
5. A Status 200 in the right pane means the query for a single submission was a success.
6. To query for all submissions, click Query in the left pane, then click the `+` next to `submissions`, then `id: ID!`.
7. Click the blue Query button in the middle pane.
8. A Status 200 in the right pane means the query for all submissions was a success.
