### PR TITLE
feat: add a submissionService file and Submission type definitions

### DIFF
--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -1,0 +1,116 @@
+import { Submission } from '../typeDefs/dbSchema'
+import { DocumentData, getFirestore } from 'firebase-admin/firestore'
+import { SpokenLanguage, SpokenLanguageInput } from '../typeDefs/gqlTypes'
+
+export const getSubmissionById = async (id: string) : Promise<Submission | null> => {
+    try {
+        const db = getFirestore()
+        const submissionRef = db.collection('submissions')
+        const snapshot = await submissionRef.doc(id).get()
+
+        if (!snapshot.exists) {
+            return null
+        }
+
+        const convertedEntity = mapDbEntityTogqlEntity(snapshot.data() as DocumentData)
+
+        return convertedEntity
+    } catch (error) {
+        throw new Error(`Failed to retrieve submission: ${error}.`)
+    }
+}
+
+function convertToDbSubmission(submission: import('../typeDefs/gqlTypes').Submission): 
+    import('../typeDefs/dbSchema').Submission {
+    return {
+        ...submission,
+        spokenLanguages: submission.spokenLanguages
+            .filter(lang => lang !== null) as import('../typeDefs/dbSchema').SpokenLanguage[]
+    }
+}
+
+export const addSubmission = async (submission: import('../typeDefs/gqlTypes').Submission) : Promise<Submission> => {
+    try {
+        const dbSubmission = convertToDbSubmission(submission)
+
+        const db = getFirestore()
+        const submissionRef = db.collection('submissions')
+
+        const docRef = await submissionRef.add(dbSubmission)
+
+        const newSubmission: Submission = {
+            ...dbSubmission,
+            id: docRef.id
+        }
+
+        return newSubmission
+    } catch (error) {
+        throw new Error(`Failed to add submission: ${error}.`)
+    }
+}
+
+export const updateSubmission = async (id: string, updatedFields: Partial<Submission>) : Promise<string> => {
+    try {
+        const db = getFirestore()
+        const submissionRef = db.collection('submissions').doc(id)
+
+        const snapshot = await submissionRef.get()
+
+        const submissionToUpdate = mapDbEntityTogqlEntity(snapshot.data() as DocumentData)
+
+        const updatedSubmission: Submission = {
+            ...submissionToUpdate,
+            ...updatedFields
+        }
+
+        await submissionRef.update(updatedSubmission)
+
+        return 'Submission updated successfully!'
+    } catch (error) {
+        throw new Error(`Failed to update submission: ${error}.`)
+    }
+}
+
+// There was a mismatch between the `SpokenLanguage` type in `gqlTypes` and `dbSchema`
+function gqlSpokenLanguageToDbSpokenLanguage(lang: SpokenLanguage): import('../typeDefs/dbSchema').SpokenLanguage {
+    return {
+        iso639_3: lang.iso639_3 as string,
+        nameJa: lang.nameJa as string,
+        nameEn: lang.nameEn as string,
+        nameNative: lang.nameNative as string
+    }
+}
+
+export const mapAndValidateSpokenLanguages = (spokenLanguages: SpokenLanguageInput[]): 
+    import('../typeDefs/dbSchema').SpokenLanguage[] | undefined => {
+    if (!spokenLanguages || ! spokenLanguages.length) { return undefined }
+
+    const validatedLanguages = spokenLanguages
+        .filter(lang => lang && lang.iso639_3 && lang.nameJa && lang.nameEn && lang.nameNative)
+        .map(lang => ({
+            iso639_3: lang.iso639_3 as string,
+            nameJa: lang.nameJa as string,
+            nameEn: lang.nameEn as string,
+            nameNative: lang.nameNative as string
+        }))
+    
+    if (validatedLanguages.length !== spokenLanguages.length) {
+        throw new Error('Some spoken languages are missing required fields.')
+    }
+
+    return validatedLanguages.map(gqlSpokenLanguageToDbSpokenLanguage)
+}
+
+const mapDbEntityTogqlEntity = (dbEntity: DocumentData) : Submission => {
+    const gqlEntity = {
+        id: dbEntity.id,
+        googleMapsUrl: dbEntity.googleMapsUrl,
+        healthcareProfessionalName: dbEntity.healthcareProfessionalName,
+        spokenLanguages: dbEntity.spokenLanguages,
+        isUnderReview: dbEntity.isUnderReview,
+        isApproved: dbEntity.isApproved,
+        isRejected: dbEntity.isRejected
+    }
+
+    return gqlEntity
+}

--- a/src/typeDefs/dbSchema.ts
+++ b/src/typeDefs/dbSchema.ts
@@ -54,6 +54,22 @@ export type SpokenLanguage = {
   nameNative: string
 }
 
+export type Submission = {
+  id: string,
+  googleMapsUrl: string,
+  healthcareProfessionalName: string,
+  spokenLanguages: SpokenLanguage[],
+  isUnderReview: boolean,
+  isApproved: boolean,
+  isRejected: boolean
+}
+
+export type SubmissionFilters = {
+  isUnderReview?: boolean,
+  isApproved?: boolean,
+  isRejected?: boolean
+}
+
 export type Degree = {
   id: string
   nameJa: string

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -131,8 +131,8 @@ type SpokenLanguage {
 
 type Submission {
   id: ID!
-  submittedLink: String!
-  healthCareProfessionalName: String!
+  googleMapsUrl: String!
+  healthcareProfessionalName: String!
   spokenLanguages: [SpokenLanguage]!
   isUnderReview: Boolean!
   isApproved: Boolean!
@@ -140,8 +140,8 @@ type Submission {
 }
 
 input SubmissionInput {
-  submittedLink: String!
-  healthCareProfessionalName: String!
+  googleMapsUrl: String!
+  healthcareProfessionalName: String!
   spokenLanguages: [SpokenLanguageInput]!
 }
 
@@ -182,5 +182,12 @@ type Mutation {
   ) : HealthcareProfessional
   createFacilityWithHealthcareProfessional(
     input: FacilityInput
-  ) : Facility
+  ): Facility
+  createSubmission(
+    input: SubmissionInput
+  ): Submission
+  updateSubmission(
+    id: ID!
+    input: SubmissionInput
+  ): Submission
 }


### PR DESCRIPTION
Previously there were no service functions to allow users to get, add, or update submissions. There are now functions to perform these tasks. There is now also a Submission type alias in `TypeDefs/dbschema.ts`.

Part of #212 

This PR is part of a 🥞:
1. https://github.com/ourjapanlife/findadoc-server/pull/213 <- You are here
2. https://github.com/ourjapanlife/findadoc-server/pull/218 


# What changed
1. Added a type alias called `Submission` to `dbSchema.ts` to define the data types for each field.
3. Created a file in `src/services` called `submissionService.ts` to house the submission-related functions.
4. Added three main functions: 
- **`getSubmissionById`**: Retrieves a specific submission by its ID.
- **`addSubmission`**: Adds a new submission.
- **`updateSubmission`** : Updates an existing submission.
5. Added the `mapDbEntityTogqlEntity` function to ensure that data is structured in the desired format for GraphQL presentation.
6. Added `submission`, `createSubmission`, and `updateSubmission` to `resolvers.ts`.

# Testing instructions
1. Run the development server using `yarn dev`.
2. Open your browser and navigate to http://localhost:3001 to access the GraphQL Studio.
3. In the GraphQL Studio, click the explorer button on the left.
4. Under **Root Types**, click the `+` next to `mutation: Mutation`.
5. Under **Fields**, click the `+` next to `createSubmission`.
7. in the middle pane, under **Operation**, copy and past the following:
```
mutation Mutation($input: SubmissionInput) {
  createSubmission(input: $input) {
    id
    googleMapsUrl
    healthcareProfessionalName
    spokenLanguages {
      iso639_3
      nameJa
      nameEn
      nameNative
    }
    isUnderReview
    isApproved
    isRejected
  }
}
```
8. In the middle pane, under **Variables**, copy and paste the following:
```
{
  "input": {
    "googleMapsUrl": "https://maps.google.com/example",
    "healthcareProfessionalName": "Enter Name Here",
    "spokenLanguages": [
      {
        "iso639_3": "eng",
        "nameJa": "English",
        "nameEn": "English",
        "nameNative": "English"
      }
    ]
  }
}
```
9. Click the blue **Mutation** button. The result in the right pane should match the structure of this example:
```
{
  "data": {
    "createSubmission": {
      "id": "actual_id_here",
      "googleMapsUrl": "https://maps.google.com/kitty-clinic",
      "healthcareProfessionalName": "Dr. Carlos",
      "spokenLanguages": [
        {
          "iso639_3": "eng",
          "nameJa": "meow meow meow",
          "nameEn": "meow meow meow",
          "nameNative": "meow meow meow"
        }
      ],
      "isUnderReview": true,
      "isApproved": false,
      "isRejected": false
    }
  }
}
```
10. Check the **submissions collection** in Firestore to confirm successful creation.