### PR TITLE
Remove codeowners until the repo goes public

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,0 @@
-# This is a comment.
-# Each line is a file pattern followed by one or more owners.
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-* @theyokohamalife @ermish @jbcden


### PR DESCRIPTION
# What changed

Temporarily removing CODEOWNERS, because it's placing a burden on development with a team so small on a private repository.

