### PR TITLE
feat: make error code consistent

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,7 +14,7 @@ const CustomErrors = {
     missingInput: (message: string) => {
         throw new GraphQLError(message, {
             extensions: {
-                code: 'MISSING INPUT',
+                code: 'MISSING_INPUT',
                 http: {
                     status: 400
                 }


### PR DESCRIPTION
Previous to this commit in the errors file, missingInput was missing an underscore what made the error codes not consistent. In this commit I have added a underscore.

Resolves #247 
