### PR TITLE
Add error messages/handeling to resolvers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,11 +19,10 @@ export const createApolloServer = async () => {
             //enables the apollo sanbox as the landing page
             ApolloServerPluginLandingPageLocalDefault()
         ],
-        formatError: (formattedError, error) => {
-            return {
-                message: formattedError.message
-            }
-        }
+        // Allows you to choose what error info is visable for client side
+        formatError: (formattedError) => ({
+            message: formattedError.message
+        })
     })
   
     console.log('⛽️ Starting server...')

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export const createApolloServer = async () => {
             ApolloServerPluginLandingPageLocalDefault()
         ],
         // Allows you to choose what error info is visable for client side
-        formatError: (formattedError) => ({
+        formatError: formattedError => ({
             message: formattedError.message
         })
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,12 @@ export const createApolloServer = async () => {
         plugins: [
             //enables the apollo sanbox as the landing page
             ApolloServerPluginLandingPageLocalDefault()
-        ]
+        ],
+        formatError: (formattedError, error) => {
+            return {
+                message: formattedError.message
+            }
+        }
     })
   
     console.log('⛽️ Starting server...')

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -94,7 +94,7 @@ const resolvers = {
             } catch (error) {
                 console.error(error)
                 console.log('INPUT_FIELD:', JSON.stringify(args))
-                return CustomErrors.missingInput('Failed to create facility with healthcare prof. Please make sure the input fields are correct')
+                return CustomErrors.missingInput('Failed to create facility and Healthcare Professional.')
             }  
         },
         createHealthcareProfessional: async (_parent: gqlType.HealthcareProfessional, args: {
@@ -116,7 +116,7 @@ const resolvers = {
             } catch (error) {
                 console.log(error)
                 console.log('INPUT_FIELD:', JSON.stringify(args))
-                return CustomErrors.missingInput('Failed to create the healthcare professional. Please make sure the input fields are correct.')
+                return CustomErrors.missingInput('Failed to create the healthcare professional.')
             }
         },
         createSubmission: async (_parent: gqlType.Submission, args: {
@@ -157,7 +157,7 @@ const resolvers = {
             } catch (error) {
                 console.log(error)
                 console.log('INPUT_FIELDS:', JSON.stringify(args))
-                return CustomErrors.missingInput('Failed to create submission. Please make sure the input fields are filled out correctly')
+                return CustomErrors.missingInput('Failed to create submission.')
             }
         },
         updateSubmission: async (_parent: gqlType.Submission, args: {
@@ -192,7 +192,7 @@ const resolvers = {
             } catch (error) {
                 console.log(error)
                 console.log('INPUT_FIELDS:', JSON.stringify(args))
-                return CustomErrors.missingInput('Failed to update the submission. Please make sure the input fields are correct.')
+                return CustomErrors.missingInput('Failed to update the submission.')
             }
         }
     }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -12,19 +12,22 @@ const resolvers = {
 
                 return matchingFacilities
             } catch (error) {
-                return CustomErrors.notFound(`Failed to find facilities: ${error}`)
+                console.log(error)
+                return CustomErrors.notFound(`No facilities where found.`)
             } 
         },
-        facility: async (_parent: gqlType.Facility, args: { id: string; }) => {
+        facility: async (_parent: gqlType.Facility, args: { id: string; }, contextValue: any) => {
             try {
                 if (!args.id || !args.id.trim()) {
                     throw new Error('An ID was not provided')
                 }
+                console.log(contextValue.dataSources)
                 const matchingFacility = await facilityService.getFacilityById(args.id)
 
                 return matchingFacility            
             } catch (error) {
-                return CustomErrors.notFound(`Failed to find the facility: ${error}`)
+                console.error(error)
+                return CustomErrors.notFound(`The facility does not exist.`)
             } 
         },
         // healthcareProfessionals: async () => {
@@ -42,7 +45,8 @@ const resolvers = {
 
                 return matchingHealthcareProfessional        
             } catch (error) {
-                return CustomErrors.notFound(`${error}`)
+                console.error(error)
+                return CustomErrors.notFound('The healthcare professional does not exist.')
             }  
         },
         submissions: async (_parent: gqlType.Submission, args: { filters: gqlType.SubmissionSearchFilters }) => {
@@ -53,7 +57,8 @@ const resolvers = {
 
                 return matchingSubmissions
             } catch (error) {
-                return CustomErrors.notFound(`Failed to find submissions: ${error}`)
+                console.error(error)
+                return CustomErrors.notFound(`No submissions where found.`)
             }
         },
         submission: async (_parent: gqlType.Submission, args: { id: string }) => {
@@ -65,7 +70,8 @@ const resolvers = {
 
                 return matchingSubmission           
             } catch (error) {
-                return CustomErrors.notFound(`Failed to find the submission: ${error}`)
+                console.error(error)
+                return CustomErrors.notFound(`The submission does not exist.`)
             }  
         }
     },
@@ -83,7 +89,8 @@ const resolvers = {
 
                 return newFacility
             } catch (error) {
-                return CustomErrors.missingInput(`Failed to create facility with healthcare professional: ${error}`)
+                console.error(error)
+                return CustomErrors.missingInput(`Failed to create facility with healthcare professional.`)
             }  
         },
         createHealthcareProfessional: async (_parent: gqlType.HealthcareProfessional, args: {
@@ -136,7 +143,8 @@ const resolvers = {
     
                 return newSubmission
             } catch (error) {
-                return CustomErrors.missingInput(`Failed to create submission: ${error}`)
+                console.log(error)
+                return CustomErrors.missingInput(`Failed to create submission`)
             }
         },
         updateSubmission: async (_parent: gqlType.Submission, args: {

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -3,7 +3,6 @@ import * as healthcareProfessionalService from './services/healthcareProfessiona
 import * as gqlType from './typeDefs/gqlTypes'
 import * as submissionService from './services/submissionService'
 import CustomErrors from './errors'
-import { json } from 'stream/consumers'
 
 const resolvers = {
     Query: {
@@ -14,7 +13,7 @@ const resolvers = {
                 return matchingFacilities
             } catch (error) {
                 console.log(error)
-                return CustomErrors.notFound(`No facilities where found.`)
+                return CustomErrors.notFound('No facilities where found.')
             } 
         },
         facility: async (_parent: gqlType.Facility, args: { id: string; }) => {
@@ -28,7 +27,7 @@ const resolvers = {
             } catch (error) {
                 console.log(error)
                 console.log('ID:', JSON.stringify(args))
-                return CustomErrors.notFound(`The facility does not exist.`)
+                return CustomErrors.notFound('The facility does not exist.')
             } 
         },
         // healthcareProfessionals: async () => {
@@ -61,7 +60,7 @@ const resolvers = {
             } catch (error) {
                 console.log(error)
                 console.log('FILTERS:', JSON.stringify(args))
-                return CustomErrors.notFound(`No submissions where found.`)
+                return CustomErrors.notFound('No submissions where found.')
             }
         },
         submission: async (_parent: gqlType.Submission, args: { id: string }) => {
@@ -75,7 +74,7 @@ const resolvers = {
             } catch (error) {
                 console.log(error)
                 console.log('ID:', JSON.stringify(args))
-                return CustomErrors.notFound(`The submission does not exist.`)
+                return CustomErrors.notFound('The submission does not exist.')
             }  
         }
     },
@@ -94,8 +93,8 @@ const resolvers = {
                 return newFacility
             } catch (error) {
                 console.error(error)
-                console.log('INPUT_FIELD:',JSON.stringify(args))
-                return CustomErrors.missingInput(`Failed to create facility with healthcare professional. Please make sure the input fields are filled out correctly`)
+                console.log('INPUT_FIELD:', JSON.stringify(args))
+                return CustomErrors.missingInput('Failed to create facility with healthcare prof. Please make sure the input fields are correct')
             }  
         },
         createHealthcareProfessional: async (_parent: gqlType.HealthcareProfessional, args: {
@@ -116,8 +115,8 @@ const resolvers = {
                 return newHealthcareProfessional
             } catch (error) {
                 console.log(error)
-                console.log('INPUT_FIELD:',JSON.stringify(args))
-                return CustomErrors.missingInput(`Failed to create the healthcare professional. Please make sure the input fields are filled out correctly`)
+                console.log('INPUT_FIELD:', JSON.stringify(args))
+                return CustomErrors.missingInput('Failed to create the healthcare professional. Please make sure the input fields are correct.')
             }
         },
         createSubmission: async (_parent: gqlType.Submission, args: {
@@ -157,8 +156,8 @@ const resolvers = {
                 return newSubmission
             } catch (error) {
                 console.log(error)
-                console.log('INPUT_FIELDS:',JSON.stringify(args))
-                return CustomErrors.missingInput(`Failed to create submission. Please make sure the input fields are filled out correctly`)
+                console.log('INPUT_FIELDS:', JSON.stringify(args))
+                return CustomErrors.missingInput('Failed to create submission. Please make sure the input fields are filled out correctly')
             }
         },
         updateSubmission: async (_parent: gqlType.Submission, args: {
@@ -190,10 +189,10 @@ const resolvers = {
                 const updatedSubmission = await submissionService.getSubmissionById(args.id)
 
                 return updatedSubmission
-            } catch (error: any) {
+            } catch (error) {
                 console.log(error)
-                console.log('INPUT_FIELDS:',JSON.stringify(args))
-                return CustomErrors.missingInput('Failed to update the submission. Please make sure the input fields are filled out correctly')
+                console.log('INPUT_FIELDS:', JSON.stringify(args))
+                return CustomErrors.missingInput('Failed to update the submission. Please make sure the input fields are correct.')
             }
         }
     }


### PR DESCRIPTION
Previously, resolvers were missing try and catch blocks and this caused undesired behavior when making a query or mutation request when they missed required values/fields.

Resolves #255 


# What changed
1. Added try and catch blocks to all resolvers
2. Added the custom errors in the catch block

# Testing instructions

If you would make a mutation, example create submission, without an id as followed, it will throw an error now:

```mutation Mutation($input: SubmissionInput) {
  createSubmission(input: $input) {
    googleMapsUrl
    healthcareProfessionalName
    spokenLanguages {
      iso639_3
      nameEn
      nameJa
      nameNative
    }
  }
}
```
