### PR TITLE
Refactor the error message tests

### DIFF
--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -106,8 +106,6 @@ describe('query healthcareProfessionalById', () => {
         const mySchema = addResolversToSchema({schema, resolvers})
         const preserveResolvers = true
         const mocks = {}
-
-        const spyCustomeErrors = jest.spyOn(CustomErrors, 'notFound')
         
         server = mockServer(mySchema, mocks, preserveResolvers)
 
@@ -118,8 +116,6 @@ describe('query healthcareProfessionalById', () => {
         expect(errors[0].extensions.http).toEqual({status: 404})
         expect(errors.length).toBe(1)
         expect(errors[0].extensions.code).toBe('NOT_FOUND')
-        expect(errors[0].message).toBeDefined()
-        expect(errors[0].message.length).toBeGreaterThan(0)
-        expect(spyCustomeErrors).toHaveBeenCalled()
+        expect(errors[0].message).toBe('The healthcare professional does not exist.')
     })
 })

--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -7,6 +7,7 @@ import fs from 'fs'
 import path from 'path'
 import * as gqlTypes from '../src/typeDefs/gqlTypes'
 import { initiatilizeFirebaseInstance } from '../src/firebaseDb'
+import CustomErrors from '../src/errors'
 
 const schema = buildSchema(fs.readFileSync(
     path.join(__dirname, '../src/typeDefs/schema.graphql'),
@@ -51,6 +52,10 @@ const queryData = {
 
 describe('query healthcareProfessionalById', () => {    
     let server: IMockServer
+
+    afterEach(() => {
+        jest.restoreAllMocks()
+    })
     
     it('successfully returns a healthcare professional', async () => {
         await initiatilizeFirebaseInstance()
@@ -102,6 +107,8 @@ describe('query healthcareProfessionalById', () => {
         const preserveResolvers = true
         const mocks = {}
 
+        const spyCustomeErrors = jest.spyOn(CustomErrors, 'notFound')
+        
         server = mockServer(mySchema, mocks, preserveResolvers)
 
         const response = await server.query(queryData.query, queryData.variables)
@@ -111,6 +118,8 @@ describe('query healthcareProfessionalById', () => {
         expect(errors[0].extensions.http).toEqual({status: 404})
         expect(errors.length).toBe(1)
         expect(errors[0].extensions.code).toBe('NOT_FOUND')
-        expect(errors[0].message).toBe('Healthcare professional not found.')
+        expect(errors[0].message).toBeDefined()
+        expect(errors[0].message.length).toBeGreaterThan(0)
+        expect(spyCustomeErrors).toHaveBeenCalled()
     })
 })

--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -7,7 +7,6 @@ import fs from 'fs'
 import path from 'path'
 import * as gqlTypes from '../src/typeDefs/gqlTypes'
 import { initiatilizeFirebaseInstance } from '../src/firebaseDb'
-import CustomErrors from '../src/errors'
 
 const schema = buildSchema(fs.readFileSync(
     path.join(__dirname, '../src/typeDefs/schema.graphql'),

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -9,7 +9,7 @@ export async function getHealthcareProfessionalById(id: string) {
     const snapshot = await healthcareProfessionalRef.where('id', whereCondition, id).get()
 
     if (snapshot.docs.length < 1) {
-        CustomErrors.notFound('Healthcare professional not found.')
+        CustomErrors.notFound('The healthcare professional does not exist.')
     }
 
     const convertedEntity = mapDbEntityTogqlEntity(snapshot.docs[0].data())


### PR DESCRIPTION
Previously, the test only passed if the error message matched the tested sentence exactly. To make a more dynamic I refactor the way we test the error message.

Resolves #262 

# What changed
Refactor the tests for the error path, focusing more on the error message. Add a spyOn mock function to verify if Customerrors.notFound() has been called. Also, test the error message by checking if it is defined and has a length greater than 0, rather than a specific message.

