### PR TITLE
Add project name to dev:startlocaldb script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "scripts": {
         "dev": "echo '\n🧶 Installing yarn dependencies...🧶\n' && yarn && yarn generate && yarn dev:startserver",
         "dev:startserver": "echo '\n💻 💻 💻✨ Starting dev server...' && cross-env NODE_ENV=development ts-node-dev --no-notify --exit-child src/index.ts",
-        "dev:startlocaldb": "firebase login && firebase emulators:start --only firestore",
+        "dev:startlocaldb": "firebase login && firebase emulators:start --project='find-a-doc-japan' --only firestore",
         "test": "jest --runInBand --detectOpenHandles --forceExit --setupFiles",
         "test:dockerstart": "docker-compose -f 'docker/docker-compose-test.yml' up -d --build",
         "test:dockerstop": "docker-compose -f 'docker/docker-compose-test.yml' down",


### PR DESCRIPTION
Previously the project name was left out in the dev:startlocaldb script and this prevented the seeding from happening for certain developers

Resolves #279 
