### PR TITLE
Add error handling to healthcareprofessionalService

### DIFF
--- a/__tests__/server.test.ts
+++ b/__tests__/server.test.ts
@@ -7,6 +7,7 @@ import fs from 'fs'
 import path from 'path'
 import * as gqlTypes from '../src/typeDefs/gqlTypes'
 import { initiatilizeFirebaseInstance } from '../src/firebaseDb'
+import { ErrorCode } from '../src/result'
 
 const schema = buildSchema(fs.readFileSync(
     path.join(__dirname, '../src/typeDefs/schema.graphql'),
@@ -114,7 +115,8 @@ describe('query healthcareProfessionalById', () => {
 
         expect(errors[0].extensions.http).toEqual({status: 404})
         expect(errors.length).toBe(1)
-        expect(errors[0].extensions.code).toBe('NOT_FOUND')
+        expect(errors[0].extensions.code).toBe(ErrorCode.NOT_FOUND)
         expect(errors[0].message).toBe('The healthcare professional does not exist.')
     })
 })
+


### PR DESCRIPTION
Previously try and catch blocks and error messaging where missing from healthcareProfessionalService. To make error handling more consistent I added try and catch blocks and error messages.

Resolves #253 


# What changed
Add try and catch blocks and error messages to the healthcareProfessionalService.