### PR TITLE
test: add E2E test for newSubmission

### DIFF
--- a/__tests__/submissionService.test.ts
+++ b/__tests__/submissionService.test.ts
@@ -1,0 +1,75 @@
+import { expect } from '@jest/globals'
+import resolvers from '../src/resolvers'
+import loadSchema from '../src/schema'
+import request from 'supertest'
+import { ApolloServer } from '@apollo/server'
+import { startStandaloneServer } from '@apollo/server/standalone'
+import { initiatilizeFirebaseInstance } from '../src/firebaseDb'
+
+const queryData = {
+    query: `mutation Mutation($input: SubmissionInput) {
+        createSubmission(input: $input) {
+          id
+          googleMapsUrl
+          createdDate
+          healthcareProfessionalName
+          isApproved
+          isRejected
+          isUnderReview
+          spokenLanguages {
+            iso639_3
+            nameEn
+            nameJa
+            nameNative
+          }
+          updatedDate
+        }
+      }`,
+    variables: {
+        input: {
+            googleMapsUrl: 'http://domain.com',
+            healthcareProfessionalName: 'a',
+            spokenLanguages: [
+                {
+                    iso639_3: 'en',
+                    nameEn: 'English',
+                    nameJa: '英語',
+                    nameNative: 'English'
+                }
+            ]
+        }
+    }
+}
+
+describe('createSubmission', () => {
+    let url: string
+
+    const server = new ApolloServer({
+        typeDefs: loadSchema(),
+        resolvers
+    })
+
+    beforeAll(async () => {
+        ({ url } = await startStandaloneServer(server, {listen: { port: 0 }}))
+        await initiatilizeFirebaseInstance()
+    })
+
+    afterAll(async () => {
+        await server?.stop()
+    })
+    
+    it('creates a new Submission', async () => {
+        const response = await request(url).post('/').send(queryData)
+        
+        const inputData = queryData.variables.input
+        const newSubmissionData = response.body.data.createSubmission
+
+        expect(newSubmissionData.googleMapsUrl).toBe(inputData.googleMapsUrl)
+        expect(newSubmissionData.healthcareProfessionalName).toBe(inputData.healthcareProfessionalName)
+        expect(newSubmissionData.isApproved).toBe(false)
+        expect(newSubmissionData.isRejected).toBe(false)
+        expect(newSubmissionData.isUnderReview).toBe(false)
+        expect(newSubmissionData.spokenLanguages).toEqual(inputData.spokenLanguages)
+        expect(newSubmissionData.id).toBeDefined()
+    })
+})

--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -106,7 +106,7 @@ function convertToDbSubmission(submission: gqlType.Submission):
     return {
         ...submission,
         id: submission.id,
-        isUnderReview: true,
+        isUnderReview: false,
         isApproved: false,
         isRejected: false,
         createdDate: new Date().toISOString(),
@@ -153,8 +153,6 @@ export const addSubmission = async (submissionInput: gqlType.Submission):
     await submissionRef.set(newSubmission)
 
     addSubmissionResult.data = newSubmission
-    console.log('Generated new submission ID:', newSubmission.id)
-    console.log('newSubmission:', newSubmission)
 
     return addSubmissionResult
 }

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -298,7 +298,6 @@ export type Submission = {
 export type SubmissionInput = {
   googleMapsUrl: Scalars['String']['input'];
   healthcareProfessionalName: Scalars['String']['input'];
-  isApproved: Scalars['Boolean']['input'];
   spokenLanguages: Array<InputMaybe<SpokenLanguageInput>>;
 };
 

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -145,7 +145,6 @@ input SubmissionInput {
   googleMapsUrl: String!
   healthcareProfessionalName: String!
   spokenLanguages: [SpokenLanguageInput]!
-  isApproved: Boolean!
 }
 
 input SubmissionSearchFilters {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "include": [
         "src/**/*",
         "utils/**/*",
-        "__tests__/server.test.ts"
+        "__tests__/*"
     ],
     "exclude": [
         "node_modules"


### PR DESCRIPTION
Part of #249 
Resolves #287 

# What changed

1. Implements a test for addSubmission that sends a request through Apollo Server and checks the response against expected values. This is the first step to adding tests using real inputs instead of mock data, schema, and/or server.
2. Removes `isApproved` from SubmissionInput. The reasoning is because the value defaults to false when a new Submission is created, and shouldn't be a required field when a user completes the Submission form.
3. Changes `isUnderReview` from `true` to `false` so moderators will be able to know which Submission are being actively reviewed, and which are still in the backlog.



# Testing instructions

1. Start Firestore emulator through Docker by running: `yarn test:dockerstart`
2. Run the tests using `yarn test` or just the new test file using `yarn test --  __tests__/submissionService.test.ts`
