### PR TITLE
feat: implement updateFacility

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -92,6 +92,23 @@ const resolvers = {
                 return CustomErrors.missingInput('Failed to create facility and Healthcare Professional.')
             }  
         },
+        updateFacility: async (_parent: gqlType.Facility, args: {
+            id: string,
+            input: {
+                id: string,
+                nameEn?: string,
+                nameJa?: string,
+                contact?: gqlType.Contact,
+                healthcareProfessionalIds?: string[],
+                isDeleted?: boolean,
+                createdDate?: string,
+                updatedDate?: string
+            }
+        }) => {
+            const updatedFacility = await facilityService.updateFacility(args.id, args.input)
+
+            return updatedFacility.data
+        },
         createHealthcareProfessional: async (_parent: gqlType.HealthcareProfessional, args: {
             input:{
                 facilityId: string,

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -26,11 +26,11 @@ export type Contact = {
 };
 
 export type ContactInput = {
-  address: PhysicalAddressInput;
-  email: Scalars['String']['input'];
-  mapsLink: Scalars['String']['input'];
-  phone: Scalars['String']['input'];
-  website: Scalars['String']['input'];
+  address?: InputMaybe<PhysicalAddressInput>;
+  email?: InputMaybe<Scalars['String']['input']>;
+  mapsLink?: InputMaybe<Scalars['String']['input']>;
+  phone?: InputMaybe<Scalars['String']['input']>;
+  website?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type Degree = {
@@ -59,11 +59,12 @@ export type Facility = {
 };
 
 export type FacilityInput = {
-  contact: ContactInput;
-  healthcareProfessionalIds: Array<Scalars['String']['input']>;
-  healthcareProfessionals: Array<HealthcareProfessionalInput>;
-  nameEn: Scalars['String']['input'];
-  nameJa: Scalars['String']['input'];
+  contact?: InputMaybe<ContactInput>;
+  healthcareProfessionalIds?: InputMaybe<Array<InputMaybe<Scalars['String']['input']>>>;
+  healthcareProfessionals?: InputMaybe<Array<HealthcareProfessionalInput>>;
+  isDeleted?: InputMaybe<Scalars['Boolean']['input']>;
+  nameEn?: InputMaybe<Scalars['String']['input']>;
+  nameJa?: InputMaybe<Scalars['String']['input']>;
 };
 
 export type FacilitySearchFilters = {
@@ -131,6 +132,7 @@ export type Mutation = {
   createFacilityWithHealthcareProfessional?: Maybe<Facility>;
   createHealthcareProfessional?: Maybe<HealthcareProfessional>;
   createSubmission?: Maybe<Submission>;
+  updateFacility?: Maybe<Facility>;
   updateHealthcareProfessional?: Maybe<HealthcareProfessional>;
   updateSubmission?: Maybe<Submission>;
 };
@@ -148,6 +150,12 @@ export type MutationCreateHealthcareProfessionalArgs = {
 
 export type MutationCreateSubmissionArgs = {
   input?: InputMaybe<SubmissionInput>;
+};
+
+
+export type MutationUpdateFacilityArgs = {
+  id: Scalars['ID']['input'];
+  input?: InputMaybe<FacilityInput>;
 };
 
 
@@ -505,6 +513,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   createFacilityWithHealthcareProfessional?: Resolver<Maybe<ResolversTypes['Facility']>, ParentType, ContextType, Partial<MutationCreateFacilityWithHealthcareProfessionalArgs>>;
   createHealthcareProfessional?: Resolver<Maybe<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, Partial<MutationCreateHealthcareProfessionalArgs>>;
   createSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, Partial<MutationCreateSubmissionArgs>>;
+  updateFacility?: Resolver<Maybe<ResolversTypes['Facility']>, ParentType, ContextType, RequireFields<MutationUpdateFacilityArgs, 'id'>>;
   updateHealthcareProfessional?: Resolver<Maybe<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, RequireFields<MutationUpdateHealthcareProfessionalArgs, 'id'>>;
   updateSubmission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<MutationUpdateSubmissionArgs, 'id'>>;
 };

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -7,11 +7,11 @@ type Contact {
 }
 
 input ContactInput {
-  email: String!
-  phone: String!
-  website: String!
-  mapsLink: String!
-  address: PhysicalAddressInput!
+  email: String
+  phone: String
+  website: String
+  mapsLink: String
+  address: PhysicalAddressInput
 }
 
 type PhysicalAddress {
@@ -50,11 +50,12 @@ type Facility {
 }
 
 input FacilityInput {
-  nameEn: String!
-  nameJa: String!
-  contact: ContactInput!
-  healthcareProfessionals: [HealthcareProfessionalInput!]!,
-  healthcareProfessionalIds: [String!]!
+  nameEn: String
+  nameJa: String
+  contact: ContactInput
+  healthcareProfessionals: [HealthcareProfessionalInput!],
+  healthcareProfessionalIds: [String]
+  isDeleted: Boolean
 }
 
 input HealthcareProfessionalInput {
@@ -224,6 +225,10 @@ type Mutation {
     input: HealthcareProfessionalInput
   ) : HealthcareProfessional
   createFacilityWithHealthcareProfessional(
+    input: FacilityInput
+  ): Facility
+  updateFacility(
+    id: ID!
     input: FacilityInput
   ): Facility
   createSubmission(


### PR DESCRIPTION
Resolves #294 

This PR is part of a 🥞
1. https://github.com/ourjapanlife/findadoc-server/pull/292
2. https://github.com/ourjapanlife/findadoc-server/pull/293 👈🏼 You are here

# What changed
1. Creates the `updateFacility` mutation
4. Makes the `ContactInput` fields optional
5. Adds happy path test for `updateFacility`

# Testing instructions
1. Run `yarn test:dockerstart` to start the Docker container
3. Run `yarn test` and make sure all of the tests pass
4. Run `yarn dev` to start the local server
6. Create a new Facility in GraphQL Studio and copy the ID
7. Use the `updateFacility` mutation and make sure to pass the ID in the Variables. Example:
```json
{
  "updateFacilityId": "yu1KvHOKeb8npvdtwBsc",
  "input": {
    "nameEn": "some other facility name",
    "isDeleted": true,
    "contact": {
      "email": "happyhappy@happy.com"
    }
  },
}
```
