### PR TITLE
fix: allow for partial updates of submissions

### DIFF
--- a/__tests__/submissions.test.ts
+++ b/__tests__/submissions.test.ts
@@ -73,3 +73,83 @@ describe('createSubmission', () => {
         expect(newSubmissionData.id).toBeDefined()
     })
 })
+
+describe('updateSubmission', () => {
+    let url: string
+
+    const server = new ApolloServer({
+        typeDefs: loadSchema(),
+        resolvers
+    })
+
+    beforeAll(async () => {
+        ({ url } = await startStandaloneServer(server, {listen: { port: 0 }}))
+        await initiatilizeFirebaseInstance()
+    })
+
+    afterAll(async () => {
+        await server?.stop()
+    })
+    
+    it('updates a Submission with the fields included in the input', async () => {
+        // Create a new Submission
+        const newSubmission = await request(url).post('/').send(queryData)
+        
+        // Get the ID of the new Submission
+        const submissionId = newSubmission.body.data.createSubmission.id
+
+        // Mutation to update the Submission
+        const submissionQuery = {
+            query: `mutation Mutation($updateSubmissionId: ID!, $input: SubmissionInput) {
+                updateSubmission(id: $updateSubmissionId, input: $input) {
+                  id
+                  googleMapsUrl
+                  healthcareProfessionalName
+                  spokenLanguages {
+                    iso639_3
+                    nameJa
+                    nameEn
+                    nameNative
+                  }
+                  isUnderReview
+                  isApproved
+                  isRejected
+                  createdDate
+                  updatedDate
+                }
+              }`,
+            variables: {
+                input: {
+                    googleMapsUrl: 'http://new.com',
+                    healthcareProfessionalName: 'some NEW name',
+                    spokenLanguages: [
+                        {
+                            iso639_3: 'en',
+                            nameEn: 'English',
+                            nameJa: 'Eigo',
+                            nameNative: 'English'
+                        }
+                    ],
+                    isUnderReview: true,
+                    isApproved: true,
+                    isRejected: true
+                },
+                updateSubmissionId: submissionId
+            }
+        }
+
+        const submission = await request(url).post('/').send(submissionQuery)
+
+        // Compare the data returned in the response to the updated fields that were sent
+        const submissionResponse = submission.body.data.updateSubmission
+        const updatedFields = submissionQuery.variables.input
+
+        expect(submissionResponse.id).toBe(submissionId)
+        expect(submissionResponse.googleMapsUrl).toBe(updatedFields.googleMapsUrl)
+        expect(submissionResponse.healthcareProfessionalName).toBe(updatedFields.healthcareProfessionalName)
+        expect(submissionResponse.spokenLanguages).toEqual(updatedFields.spokenLanguages)
+        expect(submissionResponse.isApproved).toBe(updatedFields.isApproved)
+        expect(submissionResponse.isUnderReview).toBe(updatedFields.isUnderReview)
+        expect(submissionResponse.isRejected).toBe(updatedFields.isRejected)
+    })
+})

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -303,9 +303,13 @@ export type Submission = {
 };
 
 export type SubmissionInput = {
-  googleMapsUrl: Scalars['String']['input'];
-  healthcareProfessionalName: Scalars['String']['input'];
-  spokenLanguages: Array<InputMaybe<SpokenLanguageInput>>;
+  googleMapsUrl?: InputMaybe<Scalars['String']['input']>;
+  healthcareProfessionalName?: InputMaybe<Scalars['String']['input']>;
+  isApproved?: InputMaybe<Scalars['Boolean']['input']>;
+  isDeleted?: InputMaybe<Scalars['Boolean']['input']>;
+  isRejected?: InputMaybe<Scalars['Boolean']['input']>;
+  isUnderReview?: InputMaybe<Scalars['Boolean']['input']>;
+  spokenLanguages?: InputMaybe<Array<InputMaybe<SpokenLanguageInput>>>;
 };
 
 export type SubmissionSearchFilters = {

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -142,9 +142,13 @@ type Submission {
 }
 
 input SubmissionInput {
-  googleMapsUrl: String!
-  healthcareProfessionalName: String!
-  spokenLanguages: [SpokenLanguageInput]!
+  googleMapsUrl: String
+  healthcareProfessionalName: String
+  spokenLanguages: [SpokenLanguageInput]
+  isUnderReview: Boolean
+  isApproved: Boolean
+  isDeleted: Boolean
+  isRejected: Boolean
 }
 
 input SubmissionSearchFilters {


### PR DESCRIPTION
Resolves #280 


# What changed
1. Updates the schema and gqlTypes for  `SubmissionInput`
2. Refactors `getSubmissionById` to return a `<Result<Submission>>`
3. Refactors `updateSubmission` so it uses `doc.set()` instead of `doc.update()`. The reason is because `doc.set()` allows us to pass `{merge: true}` which tells Firestore to merge the changes into the existing data instead of replacing it all. ([documentation](https://firebase.google.com/docs/firestore/manage-data/add-data))
4. Adds test for the happy path for `updateSubmission`

# Testing instructions
1. Run `yarn test:dockerstart` to start the Docker container
2. Run `yarn test` and ensure the tests pass
3. Run `yarn dev` and create a new Submission and copy the ID
4.  Use the ID to update the Submission. Example:

**Operation:**
```gql
mutation Mutation($updateSubmissionId: ID!, $input: SubmissionInput) {
  updateSubmission(id: $updateSubmissionId, input: $input) {
    id
    googleMapsUrl
    healthcareProfessionalName
    spokenLanguages {
      iso639_3
      nameJa
      nameEn
      nameNative
    }
    isUnderReview
    isApproved
    isRejected
    createdDate
    updatedDate
  }
}
```

**Variables:**
```json
{
  "input": {
    "isApproved": false,
    "isRejected": false,
    "isUnderReview": true
  },
  "updateSubmissionId": "4y9ruQljhjdubuV6c598"
}
```
