### PR TITLE
fix: replace spelling typo 'where' with 'were'

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -16,7 +16,7 @@ const resolvers = {
 
                 return queryResults.data
             } catch (error) {
-                return CustomErrors.notFound('No facilities where found.')
+                return CustomErrors.notFound('No facilities were found.')
             } 
         },
         facility: async (_parent: gqlType.Facility, args: { id: string; }) => {
@@ -58,7 +58,7 @@ const resolvers = {
 
                 return matchingSubmissions
             } catch (error) {
-                return CustomErrors.notFound('No submissions where found.')
+                return CustomErrors.notFound('No submissions were found.')
             }
         },
         submission: async (_parent: gqlType.Submission, args: { id: string }) => {


### PR DESCRIPTION
Resolves #298 


# What changed

Previously there were spelling error in the error messages in the Resolver file, I have corrected the typos.