### PR TITLE
Add happy path test for searchSubmission method

### DIFF
--- a/__tests__/submissions.test.ts
+++ b/__tests__/submissions.test.ts
@@ -244,7 +244,7 @@ describe('getSubmissionById', () => {
         expect(submissionResponse.isRejected).toBe(createdSubmissionData.isRejected)
     })
 
-    it('get an error when submission does not exist', async () => {
+    it('failing: returns an error when submission does not exist', async () => {
         // Create a non existing uuid
         const submissionId = 'f34ec7a260e9'
         
@@ -277,11 +277,11 @@ describe('getSubmissionById', () => {
         const searchData = await request(url).post('/').send(submissionQuery)
 
         // Compare the data returned in the response to the updated fields that were sent
-        const submissionErrorResponse = searchData .body
+        const submissionErrorResponse = searchData.body
 
         expect(submissionErrorResponse.errors[0].message).toBe('Error: Submission was not found.')
         expect(submissionErrorResponse.errors[0].extensions.code).toBe('NOT_FOUND')
-        expect(searchData .status).toBe(404)
+        expect(searchData.status).toBe(404)
         expect(submissionErrorResponse.data.submission).toEqual(null)
     })
 })

--- a/__tests__/submissions.test.ts
+++ b/__tests__/submissions.test.ts
@@ -317,6 +317,7 @@ describe('sereachSubmissions', () => {
 
         const submission = await request(url).post('/').send(submissionQuery)
 
+        // Compare the data returned in the response to the createSubmission
         const submissionResponse = submission.body.data.submissions[0]
         
         const createdSubmission = newSubmission.body.data.createSubmission

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "echo '\n🧶 Installing yarn dependencies...🧶\n' && yarn && yarn generate && yarn dev:startserver",
         "dev:startserver": "echo '\n💻 💻 💻✨ Starting dev server...' && cross-env NODE_ENV=development ts-node-dev --no-notify --exit-child src/index.ts",
         "dev:startlocaldb": "firebase login && firebase emulators:start --project='find-a-doc-japan' --only firestore",
-        "test": "jest --runInBand --detectOpenHandles --forceExit --setupFiles",
+        "test": "jest --forceExit --maxWorkers=1 --verbose",
         "test:dockerstart": "docker-compose -f 'docker/docker-compose-test.yml' up -d --build",
         "test:dockerstop": "docker-compose -f 'docker/docker-compose-test.yml' down",
         "prod": "yarn prod:dockerstop && yarn prod:dockerstart",
@@ -38,6 +38,7 @@
         "yarn": "^3.6.3"
     },
     "devDependencies": {
+        "@firebase/rules-unit-testing": "^3.0.1",
         "@graphql-codegen/cli": "^5.0.0",
         "@graphql-codegen/typescript": "^4.0.1",
         "@graphql-codegen/typescript-resolvers": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "dev": "echo '\n🧶 Installing yarn dependencies...🧶\n' && yarn && yarn generate && yarn dev:startserver",
         "dev:startserver": "echo '\n💻 💻 💻✨ Starting dev server...' && cross-env NODE_ENV=development ts-node-dev --no-notify --exit-child src/index.ts",
         "dev:startlocaldb": "firebase login && firebase emulators:start --project='find-a-doc-japan' --only firestore",
-        "test": "jest --forceExit --maxWorkers=1 --verbose",
+        "test": "echo '\n🧶 Installing yarn dependencies...🧶\n' && yarn && jest --forceExit --maxWorkers=1",
         "test:dockerstart": "docker-compose -f 'docker/docker-compose-test.yml' up -d --build",
         "test:dockerstop": "docker-compose -f 'docker/docker-compose-test.yml' down",
         "prod": "yarn prod:dockerstop && yarn prod:dockerstart",

--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -56,6 +56,13 @@ function validateIdInput(id: string): Result<gqlTypes.Submission> {
     return validationResults
 }
 
+/**
+ * Get all the submissions in the database when no filters are provided.
+ * When there are filters provided it will return all the submissions according to the filters.
+ * @param filters An object that contains parameters to filter on. 
+ * When no parameters are provided, filters is an empty object.
+ * @returns A submissions object
+ */
 export async function searchSubmissions(filters: dbSchema.SubmissionSearchFilters = {}) {
     try {
         const {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1605,6 +1605,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@firebase/rules-unit-testing@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@firebase/rules-unit-testing@npm:3.0.1"
+  dependencies:
+    node-fetch: 2.6.7
+  peerDependencies:
+    firebase: ^10.0.0
+  checksum: 795b9fd1c2ce6d1cdfb99153e062364cc0706649c037eaf5e4cdb56064cf88d3e9380381601de5dd1e989dc35e8f09d88ef4b683bc767e07cac6acbceffe81c1
+  languageName: node
+  linkType: hard
+
 "@firebase/storage-compat@npm:0.3.2":
   version: 0.3.2
   resolution: "@firebase/storage-compat@npm:0.3.2"
@@ -6540,6 +6551,7 @@ __metadata:
   resolution: "findadoc-server@workspace:."
   dependencies:
     "@apollo/server": ^4.9.3
+    "@firebase/rules-unit-testing": ^3.0.1
     "@graphql-codegen/cli": ^5.0.0
     "@graphql-codegen/typescript": ^4.0.1
     "@graphql-codegen/typescript-resolvers": ^4.0.1


### PR DESCRIPTION
Resolves #301 

# What changed

1. Add happy path test for searchSubmission method.
2. Add tests for the different filters.
3. Add docstrings to the searchSubmission method.
4. Add test environment for the firestore emulator. After every test the emulator will now clear the data.

# To do

1. Add error path for searchSubmission
2. Add test enviroments to server.tests and facilities.test.