### PR TITLE
Set up result.errors to gqlerror converter

### DIFF
--- a/__tests__/facilities.test.ts
+++ b/__tests__/facilities.test.ts
@@ -120,6 +120,9 @@ describe('createFacilityWithHealthcareProfessional', () => {
     it('creates a new Facility with a new HealthcareProfessional', async () => {
         const response = await request(url).post('/').send(queryData)
 
+        //should not have errors
+        expect(response.body.errors).toBeUndefined()
+
         const inputData = queryData.variables.input
         const newFacilityData = response.body.data.createFacilityWithHealthcareProfessional
 
@@ -192,10 +195,13 @@ describe('getFacilityById', () => {
                 facilityId: facilityId
             }
         }
-        const facility = await request(url).post('/').send(facilityQuery)
+        const response = await request(url).post('/').send(facilityQuery)
+
+        //should not have errors
+        expect(response.body.errors).toBeUndefined()
 
         // Compare the data returned by getFacilityById to the new facility stored in the database
-        const facilityData = facility.body.data.facility
+        const facilityData = response.body.data.facility
         const inputData = queryData.variables.input
 
         expect(facilityData.id).toBe(facilityId)
@@ -229,6 +235,9 @@ describe('updateFacility', () => {
     it('updates the Facility fields included in the input', async () => {
         // Create a new facility
         const newFacility = await request(url).post('/').send(queryData)
+
+        //should not have errors
+        expect(newFacility.body.errors).toBeUndefined()
 
         // Get the ID of the new facility
         const facilityId = newFacility.body.data.createFacilityWithHealthcareProfessional.id
@@ -277,6 +286,9 @@ describe('updateFacility', () => {
             }
         }
         const facility = await request(url).post('/').send(facilityQuery)
+
+        //should not have errors
+        expect(facility.body.errors).toBeUndefined()
 
         // Compare the data returned by getFacilityById to the new facility stored in the database
         const updatedFacilityData = facility.body.data.updateFacility

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,10 @@ export const createApolloServer = async () => {
         // Allows you to choose what error info is visable for client side
         formatError: gqlError => {
             console.log('gqlError', gqlError)
-            
+
+            //these are the errors that are thrown in the resolvers using the Result.errors object
             if (gqlError.extensions?.errors) {
+                //let's format these errors similar to native apollo gql errors. 
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 const formattedErrors = (gqlError.extensions.errors as any[])
                     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import loadSchema from './schema'
 import resolvers from './resolvers'
 import { initiatilizeFirebaseInstance } from './firebaseDb'
 import { envVariables } from '../utils/environmentVariables'
+import { Error } from './result'
 
 import { ApolloServerPluginLandingPageLocalDefault } from '@apollo/server/plugin/landingPage/default'
 
@@ -20,14 +21,35 @@ export const createApolloServer = async () => {
             ApolloServerPluginLandingPageLocalDefault()
         ],
         // Allows you to choose what error info is visable for client side
-        formatError: formattedError => ({
-            message: formattedError.message
-        })
+        formatError: gqlError => {
+            console.log('gqlError', gqlError)
+            
+            if (gqlError.extensions?.errors) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                const formattedErrors = (gqlError.extensions.errors as any[])
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    .reduce((formattedError: any, error: Error) => {
+                        formattedError.path.push(error.field)
+                        formattedError.errors.push(error)
+                        return formattedError
+                    }, {
+                        path: [],
+                        errors: []
+                    })
+
+                formattedErrors.message = gqlError.message
+                formattedErrors.path = gqlError.path
+
+                return formattedErrors
+            }
+
+            return gqlError
+        }
     })
-  
+
     console.log('⛽️ Starting server...')
-    const { url } = await startStandaloneServer(server, {listen: { port: parseInt(envVariables.serverPort()) }})
-  
+    const { url } = await startStandaloneServer(server, { listen: { port: parseInt(envVariables.serverPort()) } })
+
     // eslint-disable-next-line no-console
     console.log(`\n🚀 🚀 🚀 Server ready at: ${url}\n`)
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -6,7 +6,7 @@ export type Result<T> = {
     errors?: Error[]
 }
 
-type Error = {
+export type Error = {
     field: string,
     errorCode: ErrorCode,
     httpStatus?: number,
@@ -23,7 +23,8 @@ export enum ErrorCode {
     INVALID_EMAIL = 'INVALID_EMAIL',
     INVALID_PHONE_NUMBER = 'INVALID_PHONE_NUMBER',
     INVALID_WEBSITE = 'INVALID_WEBSITE',
-    ADDHEALTHCAREPROF_FACILITYIDS_REQUIRED = 'ADDHEALTHCAREPROF_FACILITYIDS_REQUIRED'
+    ADDHEALTHCAREPROF_FACILITYIDS_REQUIRED = 'ADDHEALTHCAREPROF_FACILITYIDS_REQUIRED',
+    INTERNAL_SERVER_ERROR = 'INTERNAL_SERVER_ERROR'
 }
 
 export const CustomErrors = {

--- a/src/services/facilityService.ts
+++ b/src/services/facilityService.ts
@@ -95,7 +95,16 @@ export async function searchFacilities(filters: gqlTypes.FacilitySearchFilters =
 
         return searchResults
     } catch (error) {
-        throw new Error(`Error retrieving submissions: ${error}`)
+        console.log(`Error retrieving facilities: ${error}`)
+        
+        return {
+            hasErrors: true,
+            errors: [{
+                field: 'searchFacilities',
+                errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
+                httpStatus: 500
+            }]
+        }
     }
 }
 
@@ -113,7 +122,7 @@ export async function addFacility(facilityInput: gqlTypes.FacilityInput): Promis
         return validationResult
     }
 
-    const addFacilityResult : Result<dbSchema.Facility> = {
+    const addFacilityResult: Result<dbSchema.Facility> = {
         hasErrors: false,
         errors: []
     }
@@ -151,7 +160,7 @@ export async function addFacility(facilityInput: gqlTypes.FacilityInput): Promis
  * @param fieldsToUpdate The values that should be updated. They will be created if they don't exist.
  * @returns The updated Facility.
  */
-export const updateFacility = async (facilityId: string, fieldsToUpdate: Partial<dbSchema.Facility>): 
+export const updateFacility = async (facilityId: string, fieldsToUpdate: Partial<dbSchema.Facility>):
     Promise<Result<dbSchema.Facility | null>> => {
     try {
         const facilityRef = dbInstance.collection('facilities').doc(facilityId)
@@ -166,7 +175,7 @@ export const updateFacility = async (facilityId: string, fieldsToUpdate: Partial
             updatedDate: new Date().toISOString()
         }
 
-        await facilityRef.set(updatedFacilityValues, {merge: true})
+        await facilityRef.set(updatedFacilityValues, { merge: true })
 
         const updatedFacility = await getFacilityById(facilityRef.id)
 
@@ -348,7 +357,7 @@ function validateContactInput(contactInput: gqlTypes.ContactInput): Result<boole
             validationResults.errors?.push(...addressValidationResults.errors as [])
         }
     }
-    
+
     return validationResults
 }
 

--- a/src/services/facilityService.ts
+++ b/src/services/facilityService.ts
@@ -273,6 +273,15 @@ function validateFacilitiesSearchInput(searchInput: gqlTypes.FacilitySearchFilte
         })
     }
 
+    if (searchInput.limit && searchInput.limit < 0) {
+        validationResults.hasErrors = true
+        validationResults.errors?.push({
+            field: 'limit',
+            errorCode: ErrorCode.MIN_LIMIT,
+            httpStatus: 400
+        })
+    }
+
     return validationResults
 }
 

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -75,7 +75,7 @@ export async function addHealthcareProfessionalToFacility(
             errorCode: ErrorCode.ADDHEALTHCAREPROF_FACILITYIDS_REQUIRED,
             httpStatus: 400
         })
-        throw CustomErrors.missingInput('The list of facilityIds cannot be empty.')
+        return addHealthcareProfessionalResult
     }
 
     try {


### PR DESCRIPTION
Resolves #312
Resolves #316 
Resolves #317 


# What changed

- [x] Created a `Result.errors` to `GraphqlError` converter. When you throw a new GraphQLError with an extension called `errors`, the errorFormatter in `index.ts` will properly parse it. 
- [x] Added error mapping for every query and mutation that is currently using the `Result` object
- [x] Fixed corresponding tests 
    - [x] ensure no errors are thrown on passing tests
    - [x] failing test are now using the new error format

# Testing instructions

- run `yarn test` and validate all tests are passing
- run `yarn dev` and send a query that has invalid variables. 

Ex. search facilities and send `limit: -1` as a filter. You should see the new formatted errors

``` json
query QueryFacilities($filters: FacilitySearchFilters) {
  facilities(filters: $filters) {
    id
    contact {
      address {
        addressLine1En
        addressLine2En
        addressLine1Ja
        cityJa
        cityEn
      }
      email
      mapsLink
      phone
      website
    }
    isDeleted
    nameEn
    nameJa
    healthcareProfessionalIds
  }
}
```
``` json
variables
{
  "filters": {
    "limit": -1,
    "offset": 1,
    "nameEn": "Zoo"
  }
}
``` 
