### PR TITLE
chore: revert renovate bot back to previous confidence level

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,10 +19,6 @@
             "matchDatasources": ["docker"],
             "matchPackageNames": ["postgres"],
             "allowedVersions": "/14*/"
-        },
-        {
-            "matchConfidence": ["high", "very high"],
-            "groupName": "high merge confidence"
         }
     ]
 }


### PR DESCRIPTION
# What changed
This PR reverses the change that I to set the confidence level to high for the renovate bot updates. It hasn't opened any PRs to update the packages since then, and I suspect that the setting was either incorrectly implemented, or was set too high.  😅

