### PR TITLE
refactor: set unknown type for cookies

### DIFF
--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -13,7 +13,7 @@ describe('auth', () => {
         const { response, testUserId } = await createTestUser()
 
         //a successful auth will have cookies
-        const cookies = response.headers['set-cookie'] as string[]
+        const cookies = response.headers['set-cookie'] as unknown as string[]
 
         cookies.forEach(cookie => {
             expect(cookie).toBeDefined()


### PR DESCRIPTION
Sets the type of `cookies` to `unknown` and before `string[]`.
