### PR TITLE
enhanced professionals search

### DIFF
--- a/__tests__/submissions.test.ts
+++ b/__tests__/submissions.test.ts
@@ -58,6 +58,7 @@ describe('createSubmission', () => {
         expect(foundSubmissions.isRejected).toBe(false)
         expect(foundSubmissions.isUnderReview).toBe(false)
         expect(foundSubmissions.spokenLanguages).toEqual(originalInputValues.spokenLanguages)
+        expect(foundSubmissions.notes).toEqual(originalInputValues.notes)
     })
 })
 

--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -415,7 +415,7 @@ function mapGqlEntityToDbEntity(input: gqlTypes.CreateSubmissionInput, newId: st
         healthcareProfessionals: [],
         createdDate: new Date().toISOString(),
         updatedDate: new Date().toISOString(),
-        notes: input.notes as string
+        notes: input.notes ?? ''
     } satisfies dbSchema.Submission
 }
 


### PR DESCRIPTION
Due to a firebase limitation, professionals search can only query by one array-based field. The rest of them need to be done in the  code after the query is done. This adds the logic.

...also fixed tests that someone broke  (not me 😆 )