### PR TITLE
updated api url

### DIFF
--- a/.env.prod
+++ b/.env.prod
@@ -1,7 +1,7 @@
 TEST_ENABLED = false
 SERVER_HOST = "0.0.0.0"
 SERVER_PORT = 4000
-API_URL = "https://api.findadoc.jp/api"
+API_URL = "https://api.findadoc.jp"
 WEBSITE_URL = "https://www.findadoc.jp"
 LOGGER_GRAFANA_URL = "https://logs-prod-020.grafana.net"
 AUTH_SUPERTOKENS_URL = "https://st-prod-e4df8100-912e-11ee-b592-dd3da892ed00.aws.supertokens.io"

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -51,8 +51,8 @@ export const initializeAuth = async () => {
                         }
                     }],
                     signUpForm: {
-                        termsOfServiceLink: 'https://findadoc.jp/terms-of-service',
-                        privacyPolicyLink: 'https://findadoc.jp/privacy-policy'
+                        termsOfServiceLink: 'https://www.findadoc.jp/terms-of-service',
+                        privacyPolicyLink: 'https://www.findadoc.jp/privacy-policy'
                     }
                 }
             }),


### PR DESCRIPTION
Resolves #412


# What changed
- updated the api url to no longer be `/api`, but use the subdomain `api.findadoc.jp`

# Testing instructions
