### PR TITLE
fix: Make facility email field nullable

### DIFF
--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -19,7 +19,7 @@ export type Scalars = {
 export type Contact = {
   __typename?: 'Contact';
   address: PhysicalAddress;
-  email: Scalars['String']['output'];
+  email?: Maybe<Scalars['String']['output']>;
   googleMapsUrl: Scalars['String']['output'];
   phone: Scalars['String']['output'];
   website?: Maybe<Scalars['String']['output']>;
@@ -27,7 +27,7 @@ export type Contact = {
 
 export type ContactInput = {
   address: PhysicalAddressInput;
-  email: Scalars['String']['input'];
+  email?: InputMaybe<Scalars['String']['input']>;
   googleMapsUrl: Scalars['String']['input'];
   phone: Scalars['String']['input'];
   website?: InputMaybe<Scalars['String']['input']>;
@@ -614,7 +614,7 @@ export type ResolversParentTypes = {
 
 export type ContactResolvers<ContextType = any, ParentType extends ResolversParentTypes['Contact'] = ResolversParentTypes['Contact']> = {
   address?: Resolver<ResolversTypes['PhysicalAddress'], ParentType, ContextType>;
-  email?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   googleMapsUrl?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   phone?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   website?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -242,14 +242,14 @@ input LocalizedNameInput {
 
 type Contact {
   googleMapsUrl: String!
-  email: String!
+  email: String
   phone: String!
   website: String
   address: PhysicalAddress!
 }
 input ContactInput {
   googleMapsUrl: String!
-  email: String!
+  email: String
   phone: String!
   website: String
   address: PhysicalAddressInput!


### PR DESCRIPTION
Previously we had placeholder email addresses in our database that we did not want to display in our `SearchResultDetails` component. This PR updates the GraphQL schema to to make facility email addresses nullable.

Part of #436 


# What changed
Remove non-nullable operator `!` from GraphQL `Contact` type and `ContactInput`.

# Testing instructions
Run `npm run dev`, navigate to `http://127.0.0.1:4000/`, and run the following mutation:
**Operation**
```
mutation Mutation($input: CreateFacilityInput!) {
  createFacility(input: $input) {
    id
    nameEn
    contact {
      email
    }
    createdDate
    updatedDate
  }
}
```
**Variables**
```
{
  "input": {
    "contact": {
      "address": {
        "addressLine1En": "test",
        "addressLine1Ja": "テスト",
        "addressLine2En": "5555-55 test",
        "addressLine2Ja": "テスト5555-55",
        "cityEn": "test",
        "cityJa": "テスト",
        "postalCode": "123-0000",
        "prefectureEn": "test",
        "prefectureJa": "テスト"
      },
      //"email": null,
      "googleMapsUrl": "www.test.com",
      "phone": "080-1234-5678",
    },
    "healthcareProfessionalIds": "12345678",
    "mapLatitude": 1234,
    "mapLongitude": 5678,
    "nameEn": "Dr. test",
    "nameJa": "テスト先生"
  }
}
```
The response should include the field `"email": null`.