### PR TITLE
chore: update readMe to be more comprehensive

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,33 +72,29 @@ For security, we run a local database so we don't break production!
 npm -g i firebase-tools
 ```
 
+**To be able to run the firestore emulator you need to have Java version 11 or later installed. If not installed, please follow the next step (a.2).**
+
 #### a.2 Install Java
 
 on a mac, we recommend using [homebrew](https://brew.sh/)
 
 ```sh
-brew install java
+brew install openjdk
 ```
 
 on a windows pc, we recommend using [chocolatey](https://chocolatey.org/)
 
 ```sh
-choco install java
+choco install openjdk
 ```
+
+**You might have to restart vs code for step a.2 and a.3 all of these to take effect in the project**
 
 #### a.3 Log into Firebase CLI:
 
 ```sh
 firebase login
 ```
-
-#### a.4 Set the CLI to use the project:
-
-```sh
-firebase use --add
-```
-
-Select "Use an existing project"
 
 ### 3.b Running the database locally
 
@@ -130,7 +126,7 @@ To set up the Firebase Service Account for this project, follow these steps:
 ## 4. Run the API
 
 ```sh
-npm run dev
+npm run dev:startserver
 ```
 
 That's it!

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
         "test": "echo '🧶 Installing npm dependencies...🧶' && npm install && vitest",
         "test:dockerstart": "docker-compose -f 'docker/docker-compose-test.yml' up -d --build",
         "test:dockerstop": "docker-compose -f 'docker/docker-compose-test.yml' down",
+        "prepare": "husky install",
         "prod": "npm run prod:dockerstop && npm run prod:dockerstart",
         "prod:build": "echo '🧶 Installing npm dependencies...🧶' && npm install --immutable --immutable-cache && echo '🧹 cleaning dist folder...' && npx rimraf dist/ && echo '➡ ➡ copying files...' && npx copyfiles -a -V src/typeDefs/schema.graphql .env.prod dist && echo '💻✨ compiling code..' && tsc && echo '💻✨ successfully built!'",
         "prod:startserver": "echo '💻 💻 💻✨ Starting prod server...' && cross-env NODE_ENV=production PIDUSAGE_USE_PS=true pm2 start dist/src/index.js --no-daemon && pm2 logs --lines 100",


### PR DESCRIPTION
No issue linked due to no view for backend


# What changed
The readMe was a bit outdated and therefore I could see new people coming in trying to run the dummy data in the local database have trouble setting it up. I went through and updated the language that was there and added instructions for two parts of Java that need to be installed. I also commented out the husky command. There is no script for it. Whether there should be or not it would just be a stumbling block for people who do not know why they are getting the error or might now be familiar with how we are implementing husky and linting

# Testing instructions

You can follow step by step to see if it makes sense to you
