### PR TITLE
Add fake submissions data to seeding file

### DIFF
--- a/utils/databaseSeedTool.ts
+++ b/utils/databaseSeedTool.ts
@@ -3,7 +3,9 @@ import { createFacility } from '../src/services/facilityService.js'
 
 import { generateRandomCreateHealthcareProfessionalInputArray } from '../src/fakeData/fakeHealthcareProfessionals.js'
 import { generateRandomCreateFacilityInputArray } from '../src/fakeData/fakeFacilities.js'
+import { generateRandomCreateSubmissionInputArray } from '../src/fakeData/submissions.js'
 import { logger } from '../src/logger.js'
+import { createSubmission } from '../src/services/submissionService.js'
 
 export const seedDatabase = async () => {
     //eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -13,6 +15,7 @@ export const seedDatabase = async () => {
 
         const facilities = generateRandomCreateFacilityInputArray()
         const healthcareProfessionals = generateRandomCreateHealthcareProfessionalInputArray()
+        const submissions = generateRandomCreateSubmissionInputArray({count: 5})
         const facilityIds: string[] = []
 
         for await (const facility of facilities) {
@@ -35,6 +38,15 @@ export const seedDatabase = async () => {
             //we should fail here if we have errors
             if (createProfessionalResult.hasErrors) {
                 throw new Error(`${JSON.stringify(createProfessionalResult.errors)}`)
+            }
+        }
+
+        for await (const submission of submissions) {
+            const createSubmissionResult = await createSubmission(submission)
+
+            //we should fail here if we have errors
+            if (createSubmissionResult.hasErrors) {
+                throw new Error(`${JSON.stringify(createSubmissionResult.errors)}`)
             }
         }
     } catch (error) {


### PR DESCRIPTION
Resolves: #467 

The the fake submissions data was missing from the seeding file, therefore we did not have any seeded data for submissions

# What changed

- Add the fake data to the seeding file

# Testing instructions
Run `npm run dev:startlocaldb`
Then `npm run dev`

Visit emulator database and see the seeded data for submissions. 

# To do

This is a quick fix, so we can work on the frontend. This means I didn't check in depth that fake data is as it should be.
