### PR TITLE
BUG: Debug npm run lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "prod:dockerstop": "echo '🐳 🐳 🐳✨ Stopping docker compose...' && docker compose -f docker/docker-compose-api.yml down",
         "prod:logs": "docker logs findadoc-api -f",
         "generate": "echo '➡ ➡ ➡ Generating types from graphql schema ➡ ➡ ➡' && graphql-codegen --config ./typesgeneratorconfig.ts",
-        "lint": "ESLINT_USE_FLAT_CONFIG=true eslint -c eslint.config.js --fix .",
+        "lint": "cross-env ESLINT_USE_FLAT_CONFIG=true eslint -c eslint.config.js .",
         "lint:ci": "ESLINT_USE_FLAT_CONFIG=true eslint ."
     },
     "repository": {


### PR DESCRIPTION
Resolves #469 

After we migrated from Yarn to npm, the lint command did not work. It showed an error that it not recognize `ESLINT_USE_FLAT_CONFIG` variable. 

# What changed

- Add cross-env to the command
- I have also removed the `fix` tag, the reason is that people (including me) forget to commit those linting changes. With the fix gone your linting will fail when it catches an error, and you will be more consciously about fixing those errors.

I did not add cross-env to the `lint:ci` since that command is running fine in our ci.

# Testing instructions

Please checkout this branch and run `npm run lint` command. 
