### PR TITLE
chore: add tests and types for coordinates

### DIFF
--- a/__tests__/facilities.test.ts
+++ b/__tests__/facilities.test.ts
@@ -52,6 +52,8 @@ describe('createFacility', () => {
         expect(searchedFacility.updatedDate).toBeDefined()
         expect(searchedFacility.nameEn).toBe(originalInputValues.nameEn)
         expect(searchedFacility.nameJa).toBe(originalInputValues.nameJa)
+        expect(searchedFacility.mapLatitude).toBe(originalInputValues.mapLatitude)
+        expect(searchedFacility.mapLongitude).toBe(originalInputValues.mapLongitude)
     })
 
     test('facility/healthcareprofessional associations: Creating healthcareprofessional updates facility\'s healthcareProfessionalIds', async () => {

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -118,6 +118,8 @@ export type FacilitySubmission = {
   id?: Maybe<Scalars['ID']['output']>;
   nameEn?: Maybe<Scalars['String']['output']>;
   nameJa?: Maybe<Scalars['String']['output']>;
+  mapLatitude?: Scalars['Float']['output'];
+  mapLongitude?: Scalars['Float']['output'];
 };
 
 export type HealthcareProfessional = {


### PR DESCRIPTION
Resolves https://github.com/ourjapanlife/findadoc-server/issues/482

# What changed
-Before the facility submissions didn't have the map coordinate type so we couldn't autofill on the frontend with the types generated on the frontend by the schema on the backend. I added two tests for the query of submissions to make sure that the coordinates appeared as expected

# Testing instructions


You can go to the branch and run the tests with:

```
npm run test
```