### PR TITLE
chore: add coordinates to schema `FacilitySubmission`

### DIFF
--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -109,6 +109,8 @@ type FacilitySubmission {
   nameJa: String
   contact: Contact
   healthcareProfessionalIds: [ID!]!
+  mapLatitude: Float
+  mapLongitude: Float
 }
 
 type HealthcareProfessionalSubmission {


### PR DESCRIPTION
# What changed
I added the coordinates to the types on the backend in #482 . This one adds the types to the schema which is what generates the types for the frontend. Thanks to @Anissa3005 For explaining to me that the `schema.graphql` file is what needs to be changed

# Testing instructions
Run the server with:

```
npm generate 
```
And see if the type for the floats of the coordinates is part of the `FacilitySubmission` type.