### PR TITLE
chore: add generated types

### DIFF
--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -116,10 +116,10 @@ export type FacilitySubmission = {
   contact?: Maybe<Contact>;
   healthcareProfessionalIds: Array<Scalars['ID']['output']>;
   id?: Maybe<Scalars['ID']['output']>;
+  mapLatitude?: Maybe<Scalars['Float']['output']>;
+  mapLongitude?: Maybe<Scalars['Float']['output']>;
   nameEn?: Maybe<Scalars['String']['output']>;
   nameJa?: Maybe<Scalars['String']['output']>;
-  mapLatitude?: Scalars['Float']['output'];
-  mapLongitude?: Scalars['Float']['output'];
 };
 
 export type HealthcareProfessional = {
@@ -645,6 +645,8 @@ export type FacilitySubmissionResolvers<ContextType = any, ParentType extends Re
   contact?: Resolver<Maybe<ResolversTypes['Contact']>, ParentType, ContextType>;
   healthcareProfessionalIds?: Resolver<Array<ResolversTypes['ID']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;
+  mapLatitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
+  mapLongitude?: Resolver<Maybe<ResolversTypes['Float']>, ParentType, ContextType>;
   nameEn?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   nameJa?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;


### PR DESCRIPTION
Resolves #484 

# What changed
This updates the types that were generated by the graphQL schema changed in the PR #485 

# Testing instructions
No tests included. Just need to see that the types were updated. You can generate locally and see if they match the changes in this PR.