### PR TITLE
Refactor: remove updateSubmissions from seedingDatabase

### DIFF
--- a/utils/databaseSeedTool.ts
+++ b/utils/databaseSeedTool.ts
@@ -48,14 +48,6 @@ export const seedDatabase = async () => {
             if (createSubmissionResult.hasErrors) {
                 throw new Error(`${JSON.stringify(createSubmissionResult.errors)}`)
             }
-
-            const updateSubmissionData = generateRandomUpdateSubmissionInput()
-            const updatedSubmissionResult = await updateSubmission(createSubmissionResult.data.id, updateSubmissionData)
-
-            //we should fail here if we have errors
-            if (updatedSubmissionResult.hasErrors) {
-                throw new Error(`${JSON.stringify(updatedSubmissionResult.errors)}`)
-            }
         }
     } catch (error) {
         logger.error(`❌ Error seeding database: ${JSON.stringify(error)} ❌`)


### PR DESCRIPTION
Resolves #555 

# What changed
Since we made recently changes to the frontend, it's better to use the partial data again since that represents real case scenarios.
Besides that, with adding audit trailing this would add unnecessary audit logs.
 
I have remove the `updateSubmissions` from `seedingDatabase`. 

