### PR TITLE
fix: implement isUnderReview boolean change

### DIFF
--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -304,6 +304,7 @@ export const approveSubmission = async (submissionId: string): Promise<Result<gq
 
         //update the submission to approved
         currentSubmission.isApproved = true
+        currentSubmission.isUnderReview = false
         currentSubmission.updatedDate = new Date().toISOString()
 
         await submissionRef.set(currentSubmission, { merge: true })


### PR DESCRIPTION
Resolves #566 

# What changed
Before it just set a submission to `isApproved` but also should set `isUnderReview` to false if it has been approved.

