### PR TITLE
fix: reorder logic of creation of submission

### DIFF
--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -368,24 +368,26 @@ Promise<Result<gqlTypes.Submission>> => {
 
         logger.info(`\nDB-UPDATE: Submission ${submissionId} was approved.`)
 
-        //try creating healthcare professional(s)
-        for await (const healthcareProfessional of currentSubmission.healthcareProfessionals ?? []) {
-            const healthcareProfessionalInput
-                = healthcareProfessional satisfies gqlTypes.CreateHealthcareProfessionalInput
-            const createHealthcareProfessionalResult = await createHealthcareProfessional(healthcareProfessionalInput)
-
-            if (createHealthcareProfessionalResult.hasErrors) {
-                approveResult.errors?.concat(createHealthcareProfessionalResult.errors!)
-                return approveResult
-            }
-        }
-
         //try creating the facility
         const createFacilityResult = await createFacility(currentSubmission.facility as dbSchema.Facility)
 
         if (createFacilityResult.hasErrors) {
             approveResult.errors?.concat(createFacilityResult.errors!)
             return approveResult
+        }
+
+        //try creating healthcare professional(s)
+        for await (const healthcareProfessional of currentSubmission.healthcareProfessionals ?? []) {
+            const healthcareProfessionalInput
+                = healthcareProfessional satisfies gqlTypes.CreateHealthcareProfessionalInput
+
+            healthcareProfessionalInput.facilityIds.push(createFacilityResult.data.id)
+            const createHealthcareProfessionalResult = await createHealthcareProfessional(healthcareProfessionalInput)
+        
+            if (createHealthcareProfessionalResult.hasErrors) {
+                approveResult.errors?.concat(createHealthcareProfessionalResult.errors!)
+                return approveResult
+            }
         }
 
         return approveResult


### PR DESCRIPTION
Resolves #570 


# What changed
Before the function for `approveSubmission` had the order wrong on what needed to be created when approving a facility. Now a facility is created...and then the healthcare professionals if they need to be. Then finally the submission is changed to `isApproved` This is so that the correct order of logic exists. Also before there was a bug that we never set the data of the request to the `Submission`. Now this is set properly so we can send back the request to the frontend. All the steps should happen in this order or it should not be approved since some some error occurred in the approval process.

# Testing instructions
A test was added to test the functionality of this functionality based on this logic order.

1.  Submission is created
2. Submission is updated to `isUnderReview`
3. Submission is updated with all the necessary values for approval.
4. Submission is approved with no errors.