### PR TITLE
chore(lang): add unspecified language choice

### DIFF
--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -236,6 +236,7 @@ export enum Locale {
   ThTh = 'th_TH',
   TlPh = 'tl_PH',
   TrTr = 'tr_TR',
+  Und = 'und',
   ViVn = 'vi_VN',
   ZhCn = 'zh_CN',
   ZhHk = 'zh_HK',

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -256,6 +256,7 @@ enum Locale {
   zh_CN # Chinese (Simplified, China)
   zh_HK # Chinese (Traditional, Hong Kong SAR China)
   zh_TW # Chinese (Traditional, Taiwan)
+  und # Unspecified Language (Undefined)
 }
 
 type LocalizedName {


### PR DESCRIPTION
Resolves #587 


# What changed
There was an assumption that the user can accurately report languages. So on a new Healthcare Professional submission it is good to have this type shown as unspecified until the moderator has the chance to confirm.

