### PR TITLE
refactor: change the parameter types for createAuditLog

### DIFF
--- a/src/services/auditLogService.ts
+++ b/src/services/auditLogService.ts
@@ -9,8 +9,8 @@ export async function createAuditLog(
     action: gqlTypes.ActionType, 
     objectType: gqlTypes.ObjectType, 
     updatedBy: string, 
-    newData: Partial<dbSchema.Submission> | gqlTypes.Submission | string | null,
-    oldData: Partial<dbSchema.Submission> | gqlTypes.Submission | string | null,
+    newData: string | null,
+    oldData: string | null,
     t: Transaction
 ): Promise<AuditLogResult> {
     try {       
@@ -19,8 +19,8 @@ export async function createAuditLog(
             objectType: objectType,
             schemaVersion: gqlTypes.SchemaVersion.V1,
             updatedBy: updatedBy,
-            newValue: JSON.stringify(newData),
-            oldValue: JSON.stringify(oldData)
+            newValue: newData,
+            oldValue: oldData
         }
 
         const auditLogRef = dbInstance.collection('auditLogs').doc()

--- a/src/services/submissionService.ts
+++ b/src/services/submissionService.ts
@@ -186,7 +186,7 @@ Promise<Result<gqlTypes.Submission>> => {
                 gqlTypes.ActionType.Create, 
                 gqlTypes.ObjectType.Submission, 
                 '', 
-                newSubmission,
+                JSON.stringify(newSubmission),
                 null,
                 t
             )
@@ -272,8 +272,8 @@ Promise<Result<gqlTypes.Submission>> => {
                 gqlTypes.ActionType.Update, 
                 gqlTypes.ObjectType.Submission, 
                 updatedBy,
-                updatedSubmissionValues,
-                oldSubmission,
+                JSON.stringify(updatedSubmissionValues),
+                JSON.stringify(oldSubmission),
                 t
             )
 
@@ -393,8 +393,8 @@ Promise<Result<gqlTypes.Submission>> => {
                 gqlTypes.ActionType.Update, 
                 gqlTypes.ObjectType.Submission, 
                 updatedBy,
-                currentSubmission,
-                oldSubmission,
+                JSON.stringify(currentSubmission),
+                JSON.stringify(oldSubmission),
                 t
             )
 
@@ -502,8 +502,8 @@ Promise<Result<gqlTypes.Submission>> => {
                 gqlTypes.ActionType.Update, 
                 gqlTypes.ObjectType.Submission, 
                 updatedBy,
-                currentSubmission,
-                oldSubmission,
+                JSON.stringify(currentSubmission),
+                JSON.stringify(oldSubmission),
                 t
             )
 
@@ -565,7 +565,7 @@ export async function deleteSubmission(id: string, updatedBy: string)
                 gqlTypes.ObjectType.Submission, 
                 updatedBy,
                 null,
-                convertedEntity,
+                JSON.stringify(convertedEntity),
                 t
             )
 

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -26,7 +26,7 @@ export type AuditLog = {
   __typename?: 'AuditLog';
   actionType: ActionType;
   id: Scalars['ID']['output'];
-  newValue: Scalars['String']['output'];
+  newValue?: Maybe<Scalars['String']['output']>;
   objectType: ObjectType;
   oldValue?: Maybe<Scalars['String']['output']>;
   schemaVersion: SchemaVersion;
@@ -671,7 +671,7 @@ export type ResolversParentTypes = {
 export type AuditLogResolvers<ContextType = any, ParentType extends ResolversParentTypes['AuditLog'] = ResolversParentTypes['AuditLog']> = {
   actionType?: Resolver<ResolversTypes['ActionType'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  newValue?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  newValue?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   objectType?: Resolver<ResolversTypes['ObjectType'], ParentType, ContextType>;
   oldValue?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   schemaVersion?: Resolver<ResolversTypes['SchemaVersion'], ParentType, ContextType>;

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -171,7 +171,7 @@ type AuditLog {
   actionType: ActionType!
   objectType: ObjectType!
   schemaVersion: SchemaVersion!
-  newValue: String!
+  newValue: String
   oldValue: String
   updatedBy: String!
   updatedDate: String!

--- a/utils/submissionDataFromGoogleMaps.ts
+++ b/utils/submissionDataFromGoogleMaps.ts
@@ -1,6 +1,6 @@
 import puppeteer from 'puppeteer'
 import axios from 'axios'
-import { envVariables } from './environmentVariables'
+import { envVariables } from './environmentVariables.js'
 
 //Load the api key for google maps
 const apiKey = envVariables.googleAPIKey()


### PR DESCRIPTION
Resolves #640 

The `createAuditLog` function required refactoring because its parameter types were too restrictive, limiting its usage to adding submissions. By changing the parameters to accept string types, the function can now be implemented more flexibly across different use cases.

Additionally, I updated the GraphQL schema to make the newData field optional. This is necessary for delete operations, where the newData field needs to be set to null.

# What changed

1. Refactored the createAuditLog function to use string types for its parameters.
2. Updated the GraphQL schema to make the newData field optional.
3. Fixed an import bug in submissionDataFromGoogleMaps, this bug made it impossible to run the server.

# Testing instructions
