### PR TITLE
fix: add conditionals to allow updating specific fields

### DIFF
--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -691,16 +691,6 @@ function validateUpdateProfessionalInput(input: Partial<gqlTypes.UpdateHealthcar
         return validationResults
     }
 
-    //business rule: at least one facility id is required
-    if (input.facilityIds && input.facilityIds.length < 1) {
-        validationResults.hasErrors = true
-        validationResults.errors?.push({
-            field: 'facilityIds',
-            errorCode: ErrorCode.UPDATEPROFFESIONAL_FACILITYIDS_REQUIRED,
-            httpStatus: 400
-        })
-    }
-
     if (input.names) {
         validateNames(input.names, validationResults)
     }

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -681,8 +681,18 @@ function validateUpdateProfessionalInput(input: Partial<gqlTypes.UpdateHealthcar
         errors: []
     }
 
+    if (Object.keys(input).length < 1) {
+        validationResults.hasErrors = true
+        validationResults.errors?.push({
+            field: 'input',
+            errorCode: ErrorCode.MISSING_INPUT,
+            httpStatus: 400
+        })
+        return validationResults
+    }
+
     //business rule: at least one facility id is required
-    if (!input.facilityIds || input.facilityIds.length < 1) {
+    if (input.facilityIds && input.facilityIds.length < 1) {
         validationResults.hasErrors = true
         validationResults.errors?.push({
             field: 'facilityIds',
@@ -691,11 +701,24 @@ function validateUpdateProfessionalInput(input: Partial<gqlTypes.UpdateHealthcar
         })
     }
 
-    validateNames(input.names, validationResults)
-    validateDegrees(input.degrees, validationResults)
-    validateSpecialties(input.specialties, validationResults)
-    validateInsurance(input.acceptedInsurance, validationResults)
-    validateSpokenLanguages(input.spokenLanguages, validationResults)
+    if (input.names) {
+        validateNames(input.names, validationResults)
+    }
+    if (input.degrees) {
+        validateDegrees(input.degrees, validationResults)
+    }
+
+    if (input.specialties) {
+        validateSpecialties(input.specialties, validationResults)
+    }
+
+    if (input.acceptedInsurance) {
+        validateInsurance(input.acceptedInsurance, validationResults)
+    }
+
+    if (input.spokenLanguages) {
+        validateSpokenLanguages(input.spokenLanguages, validationResults)
+    }
 
     return validationResults
 }


### PR DESCRIPTION
Resolves #644

Previously, updating a healthcare professional required all fields to be provided. If any fields were missing, it caused validation errors.

This PR adds conditionals to the validation logic, allowing updates to one or more specific fields. For example, you can now update only the name field without providing other fields.

# What changed

1. Add conditionals to the `validateUpdateProfessionalInput` function.


# Testing instructions
