### PR TITLE
fix: import environmentVariables with .js extenstion

### DIFF
--- a/utils/submissionDataFromGoogleMaps.ts
+++ b/utils/submissionDataFromGoogleMaps.ts
@@ -1,6 +1,6 @@
 import puppeteer from 'puppeteer'
 import axios from 'axios'
-import { envVariables } from './environmentVariables'
+import { envVariables } from './environmentVariables.js'
 
 //Load the api key for google maps
 const apiKey = envVariables.googleAPIKey()


### PR DESCRIPTION
Resolves #658 

![image](https://github.com/user-attachments/assets/61fe888e-a3bb-4f0b-b4e5-559ff5076f01)

# What changed
I changed the import of the file to have the extension `.js` since when starting the server as seen in the picture above it would not find the module properly.

# Testing instructions
Run the server locally with :

```
npm run dev:startlocaldb

npm run dev
```