### PR TITLE
fix: update data type of newAuditLog  argument in createAuditLog test

### DIFF
--- a/__tests__/auditTrail.test.ts
+++ b/__tests__/auditTrail.test.ts
@@ -15,7 +15,7 @@ describe('createAuditLog', () => {
                 gqlTypes.ActionType.Create, 
                 gqlTypes.ObjectType.Submission, 
                 'user123', 
-                newAuditLog, 
+                JSON.stringify(newAuditLog), 
                 null,
                 t
             )


### PR DESCRIPTION
# What changed

Previously, there was a bug in the createAuditLog test caused by the newAuditLog argument having the wrong data type. This PR fixes the issue by updating the newAuditLog argument to the correct data type, string.

# Changes Include

1. Updated the newAuditLog argument data type to string in the createAuditLog test.