### PR TITLE
BUG: Adding fix for digitalocean build

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     },
     "homepage": "https://github.com/ourjapanlife/findadoc-server#readme",
     "engines": {
-        "node": "21.3.0"
+        "node": "21.3.0",
+        "yarn": "4.6.0"
     },
     "devDependencies": {
         "@firebase/rules-unit-testing": "^3.0.1",


### PR DESCRIPTION
Digital ocean App Platform is not properly picking up our yarn version, so the build is failing. This should be a fix for it. 
