### PR TITLE
fix: remove yarn from packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,5 @@
     },
     "resolutions": {
         "long": "^4.0.0"
-    },
-    "packageManager": "yarn@4.6.0"
+    }
 }


### PR DESCRIPTION
# What changed

This removes Yarn from the `packageManager` field in package.json. We were advised by Digital Ocean support to follow this [documentation from Heroku](https://help.heroku.com/8MEL050H/why-is-my-node-js-build-failing-because-of-no-matching-yarn-versions) in order to use Yarn v4+. This should also resolve build warnings we were seeing relating to having Yarn specified in two different fields:

```
2025-01-15T15:47:20.708414293Z [34m│[0m ! Multiple Yarn versions declared

2025-01-15T15:47:20.708559560Z [34m│[0m

2025-01-15T15:47:20.708748617Z [34m│[0m The package.json file indicates the target version of Yarn to install in two fields:

2025-01-15T15:47:20.708901361Z [34m│[0m - "packageManager": "[yarn@4.6.0](mailto:yarn@4.6.0)"

2025-01-15T15:47:20.709042956Z [34m│[0m - "engines.yarn": "4.6.0"

2025-01-15T15:47:20.709148921Z [34m│[0m

2025-01-15T15:47:20.709300226Z [34m│[0m If both fields are present, then "packageManager" will take precedence and "[yarn@4.6.0](mailto:yarn@4.6.0)" will be installed.

2025-01-15T15:47:20.709439670Z [34m│[0m

2025-01-15T15:47:20.709563477Z [34m│[0m To ensure we install the version of Yarn you want, remove one of these fields.

2025-01-15T15:47:20.709677709Z [34m│[0m https://devcenter.heroku.com/articles/nodejs-support

2025-01-15T15:47:20.709773397Z [34m│[0m

2025-01-15T15:47:20.883295557Z [34m│[0m ! Yarn release script may conflict with "packageManager"

2025-01-15T15:47:20.883454984Z [34m│[0m

2025-01-15T15:47:20.883459304Z [34m│[0m The package.json file indicates the target version of Yarn to install with:

2025-01-15T15:47:20.883461635Z [34m│[0m - "packageManager": "[yarn@4.6.0](mailto:yarn@4.6.0)"

2025-01-15T15:47:20.883463647Z [34m│[0m

2025-01-15T15:47:20.883660827Z [34m│[0m But the .yarnrc.yml configuration indicates a vendored release of Yarn should be used with:

2025-01-15T15:47:20.883668143Z [34m│[0m - yarnPath: ".yarn/releases/yarn-4.6.0.cjs"

2025-01-15T15:47:20.883670795Z [34m│[0m

2025-01-15T15:47:20.883673226Z [34m│[0m This will cause the buildpack to install [yarn@4.6.0](mailto:yarn@4.6.0) but, when running Yarn commands, the vendored release

2025-01-15T15:47:20.883804694Z [34m│[0m at ".yarn/releases/yarn-4.6.0.cjs" will be executed instead.

2025-01-15T15:47:20.883932912Z [34m│[0m

2025-01-15T15:47:20.883943360Z [34m│[0m To ensure we install the version of Yarn you want, choose only one of the following actions:

2025-01-15T15:47:20.884262849Z [34m│[0m - Remove the "packageManager" field from package.json
```
