### PR TITLE
fix: change urls in README to consistent slug for gitbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ We love and welcome contributions to our front-end repository which can be found
 
 ### Documentation:
 - [📒 **Welcome to Find a Doc, Japan!**](https://documentation.findadoc.jp/development)
-- [🚅 **Quickstart the API**](https://app.gitbook.com/o/Hmir5Cugknp7uJaXBpz1/s/8SwzLo8dTmkYT8nK5WXz/start-coding/quickstart-the-frontend-and-backend)
-- [🚀 **Run the API**](https://app.gitbook.com/o/Hmir5Cugknp7uJaXBpz1/s/8SwzLo8dTmkYT8nK5WXz/start-coding/quickstart-the-frontend-and-backend/running-the-api-locally)
+- [🚅 **Quickstart the API**](https://documentation.findadoc.jp/development/start-coding/quickstart-the-frontend-and-backend)
+- [🚀 **Run the API**](https://documentation.findadoc.jp/development/start-coding/quickstart-the-frontend-and-backend/running-the-api-locally)
 
 ## Contributors
 


### PR DESCRIPTION
Resolves #738

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
The links in the `README` were updated to the correct urls for the second and third link

This is previous. If you loo at the changes I updated the links to have the correct slugs for the `Quickstart the API` and `Run the API`
[📒 Welcome to Find a Doc, Japan!](https://documentation.findadoc.jp/development)
[🚅 Quickstart the API](https://app.gitbook.com/o/Hmir5Cugknp7uJaXBpz1/s/8SwzLo8dTmkYT8nK5WXz/start-coding/quickstart-the-frontend-and-backend)
[🚀 Run the API](https://app.gitbook.com/o/Hmir5Cugknp7uJaXBpz1/s/8SwzLo8dTmkYT8nK5WXz/start-coding/quickstart-the-frontend-and-backend/running-the-api-locally)

## 🧪 Testing instructions
Click the links in the read me and it shouldn't ask you to log in