### PR TITLE
feat: implement updated CORS for frontend deploy previews

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -21,7 +21,19 @@ export const createApolloFastifyServer = async (customPort?: number): Promise<st
 
     //cors is a middleware that allows us to make requests from the a different url (findadoc.jp) to our server (api.findadoc.jp)
     await fastify.register(corsPlugin, {
-        origin: [envVariables.websiteURL(), 'localhost', 'http://localhost:3000', '*findadoc.netlify.app', 'https://www.findadoc.jp'],
+        origin: (origin: string | undefined, cb: (err: Error | null, allow: boolean) => void): void => {
+            const allowedOrigins = [
+                envVariables.websiteURL(),
+                'http://localhost:3000',
+                'https://www.findadoc.jp'
+            ]
+
+            const isAllowed =
+      allowedOrigins.includes(origin as string) ||
+      /^https:\/\/deploy-preview-\d+--findadoc\.netlify\.app$/.test(origin)
+
+            cb(null, isAllowed)
+        },
         allowedHeaders: ['content-type', 'authorization'],
         // methods: ['GET', 'POST', 'OPTIONS'],
         credentials: true


### PR DESCRIPTION
Resolves #779 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before our cors had a wildcard domain for . This does not work with fastify and `CORS` because the `*` wildcard only works when credentials is false.

This uses a function that takes a callback that returns true or false whether the origin is allowed by checking an array without the flag and a match with regex to match our deployment preview URLS