### PR TITLE
fix: fix typescript error with typecasting

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ export const createApolloFastifyServer = async (customPort?: number): Promise<st
 
             const isAllowed =
       allowedOrigins.includes(origin as string) ||
-      /^https:\/\/deploy-preview-\d+--findadoc\.netlify\.app$/.test(origin)
+      /^https:\/\/deploy-preview-\d+--findadoc\.netlify\.app$/.test(origin as string)
 
             cb(null, isAllowed)
         },


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Casted string as TS needs the origin to check and if there isn't an origin it is calling itself or bash. But we do not need that functionality.