### PR TITLE
refactor: add additionalInfoForPatients field to hp

### DIFF
--- a/__tests__/healthcareProfessional.test.ts
+++ b/__tests__/healthcareProfessional.test.ts
@@ -271,6 +271,7 @@ export const createHealthcareProfessionalMutation = `mutation test_createHealthc
         acceptedInsurance
         createdDate
         updatedDate
+        additionalInfoForPatients
     }
 }`
 

--- a/__tests__/healthcareProfessionalValidations.test.ts
+++ b/__tests__/healthcareProfessionalValidations.test.ts
@@ -23,7 +23,8 @@ describe('error path: validations healthcare professionals', () => {
                         degrees: testData.generateDegrees(),
                         specialties: testData.generateSpecialties(),
                         spokenLanguages: testData.generateSpokenLanguages(),
-                        acceptedInsurance: [testData.generateAcceptedInsurance()]
+                        acceptedInsurance: [testData.generateAcceptedInsurance()],
+                        additionalInfoForPatients: ''
                     }
                 }
             } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -65,7 +66,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -96,7 +98,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -137,7 +140,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -178,7 +182,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -219,7 +224,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -250,7 +256,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: [],
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -281,7 +288,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: [],
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -312,7 +320,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: [],
-                    acceptedInsurance: [testData.generateAcceptedInsurance()]
+                    acceptedInsurance: [testData.generateAcceptedInsurance()],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>
@@ -343,7 +352,8 @@ describe('error path: validations healthcare professionals', () => {
                     degrees: testData.generateDegrees(),
                     specialties: testData.generateSpecialties(),
                     spokenLanguages: testData.generateSpokenLanguages(),
-                    acceptedInsurance: []
+                    acceptedInsurance: [],
+                    additionalInfoForPatients: ''
                 }
             }
         } as gqlMutation<CreateHealthcareProfessionalInput>

--- a/src/fakeData/fakeHealthcareProfessionals.ts
+++ b/src/fakeData/fakeHealthcareProfessionals.ts
@@ -12,7 +12,8 @@ export function generateRandomCreateHealthcareProfessionalInput(
         degrees: generateDegrees(),
         specialties: generateSpecialties(),
         spokenLanguages: generateSpokenLanguages(),
-        acceptedInsurance: [faker.helpers.enumValue(gqlTypes.Insurance)]
+        acceptedInsurance: [faker.helpers.enumValue(gqlTypes.Insurance)],
+        additionalInfoForPatients: ''
     }
 }
 

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -655,7 +655,8 @@ function mapGqlEntityToDbEntity(newHealthcareProfessionalId: string,
         //business rule: createdDate cannot be set by the user.
         createdDate: new Date().toISOString(),
         //business rule: updatedDate is updated on every change.
-        updatedDate: new Date().toISOString()
+        updatedDate: new Date().toISOString(),
+        additionalInfoForPatients: input.additionalInfoForPatients as string
     } satisfies dbSchema.HealthcareProfessional
 }
 
@@ -670,7 +671,8 @@ function mapDbEntityTogqlEntity(dbEntity: DocumentData)
         acceptedInsurance: dbEntity.acceptedInsurance,
         facilityIds: dbEntity.facilityIds,
         createdDate: new Date().toISOString(),
-        updatedDate: new Date().toISOString()
+        updatedDate: new Date().toISOString(),
+        additionalInfoForPatients: dbEntity.additionalInfoForPatients
     } satisfies gqlTypes.HealthcareProfessional
 
     return gqlEntity

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -62,6 +62,7 @@ export type CreateFacilityInput = {
 
 export type CreateHealthcareProfessionalInput = {
   acceptedInsurance?: InputMaybe<Array<Insurance>>;
+  additionalInfoForPatients?: InputMaybe<Scalars['String']['input']>;
   degrees?: InputMaybe<Array<Degree>>;
   facilityIds: Array<Scalars['ID']['input']>;
   names: Array<LocalizedNameInput>;
@@ -144,6 +145,7 @@ export type FacilitySubmission = {
 export type HealthcareProfessional = {
   __typename?: 'HealthcareProfessional';
   acceptedInsurance: Array<Insurance>;
+  additionalInfoForPatients?: Maybe<Scalars['String']['output']>;
   createdDate: Scalars['String']['output'];
   degrees: Array<Degree>;
   facilityIds: Array<Scalars['ID']['output']>;
@@ -528,6 +530,7 @@ export type UpdateFacilityInput = {
 
 export type UpdateHealthcareProfessionalInput = {
   acceptedInsurance?: InputMaybe<Array<Insurance>>;
+  additionalInfoForPatients?: InputMaybe<Scalars['String']['input']>;
   degrees?: InputMaybe<Array<Degree>>;
   facilityIds?: InputMaybe<Array<Relationship>>;
   names?: InputMaybe<Array<LocalizedNameInput>>;
@@ -751,6 +754,7 @@ export type FacilitySubmissionResolvers<ContextType = any, ParentType extends Re
 
 export type HealthcareProfessionalResolvers<ContextType = any, ParentType extends ResolversParentTypes['HealthcareProfessional'] = ResolversParentTypes['HealthcareProfessional']> = {
   acceptedInsurance?: Resolver<Array<ResolversTypes['Insurance']>, ParentType, ContextType>;
+  additionalInfoForPatients?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   createdDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   degrees?: Resolver<Array<ResolversTypes['Degree']>, ParentType, ContextType>;
   facilityIds?: Resolver<Array<ResolversTypes['ID']>, ParentType, ContextType>;

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -60,6 +60,7 @@ type HealthcareProfessional {
   facilityIds: [ID!]!
   createdDate: String!
   updatedDate: String!
+  additionalInfoForPatients: String
 }
 
 input CreateHealthcareProfessionalInput {
@@ -69,6 +70,7 @@ input CreateHealthcareProfessionalInput {
   specialties: [Specialty!]
   acceptedInsurance: [Insurance!]
   facilityIds: [ID!]!
+  additionalInfoForPatients: String
 }
 
 input UpdateHealthcareProfessionalInput {
@@ -78,6 +80,7 @@ input UpdateHealthcareProfessionalInput {
   specialties: [Specialty!]
   acceptedInsurance: [Insurance!]
   facilityIds: [Relationship!]
+  additionalInfoForPatients: String
 }
 
 # You can search for healthcare professional using any of combination these fields (AND operators)


### PR DESCRIPTION
Resolves #802
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

Added an `additionalInfoForPatients` field to hp schema so that we can display additional information that clinics want patients to know about. It's an optional field that by default will be an empty string

## 🧪 Testing instructions

Try starting the local db and local server and see if you can see the new field in the fake hp data (it should be there as empty strings). You can also test the update by trying to send an update request to make a new string for the additionalInfoForPatients field