### PR TITLE
fix: add additional info to HealthcareProfessionalSubmission

### DIFF
--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -172,6 +172,7 @@ export type HealthcareProfessionalSearchFilters = {
 export type HealthcareProfessionalSubmission = {
   __typename?: 'HealthcareProfessionalSubmission';
   acceptedInsurance?: Maybe<Array<Insurance>>;
+  additionalInfoForPatients?: Maybe<Scalars['String']['output']>;
   degrees?: Maybe<Array<Degree>>;
   facilityIds: Array<Scalars['ID']['output']>;
   id?: Maybe<Scalars['ID']['output']>;
@@ -768,6 +769,7 @@ export type HealthcareProfessionalResolvers<ContextType = any, ParentType extend
 
 export type HealthcareProfessionalSubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['HealthcareProfessionalSubmission'] = ResolversParentTypes['HealthcareProfessionalSubmission']> = {
   acceptedInsurance?: Resolver<Maybe<Array<ResolversTypes['Insurance']>>, ParentType, ContextType>;
+  additionalInfoForPatients?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
   degrees?: Resolver<Maybe<Array<ResolversTypes['Degree']>>, ParentType, ContextType>;
   facilityIds?: Resolver<Array<ResolversTypes['ID']>, ParentType, ContextType>;
   id?: Resolver<Maybe<ResolversTypes['ID']>, ParentType, ContextType>;

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -130,6 +130,7 @@ type HealthcareProfessionalSubmission {
   degrees: [Degree!]
   specialties: [Specialty!]
   acceptedInsurance: [Insurance!]
+  additionalInfoForPatients: String
   facilityIds: [ID!]!
 }
 


### PR DESCRIPTION
Resolves #828 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

I recently created 'additional info for patients' field for hp. However, I forgot to add this to HealthcareProfessionalSubmission type as well. This is necessary to also make hp additional info changes to a submission as well as just from the hp edit page 

## 🧪 Testing instructions

check it out!