### PR TITLE
feat: batching queries and create pagination

### DIFF
--- a/src/services/facilityService.ts
+++ b/src/services/facilityService.ts
@@ -8,6 +8,7 @@ import { MapDefinedFields } from '../../utils/objectUtils.js'
 import { updateHealthcareProfessionalsWithFacilityIdChanges } from './healthcareProfessionalService.js'
 import { logger } from '../logger.js'
 import { createAuditLog } from './auditLogService.js'
+import { chunkArray } from '../../utils/arrayUtils.js'
 
 /**
  * Gets the Facility from the database that matches on the id.
@@ -385,11 +386,6 @@ export async function updateFacilitiesWithHealthcareProfessionalIdChanges(
         }
 
         const MAX_BATCH_SIZE = 30
-
-        function chunkArray<T>(arr: T[], size: number): T[][] {
-            return Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
-                arr.slice(i * size, i * size + size))
-        }
 
         const allFacilitiesIds = facilitiesToUpdate.map(f => f.otherEntityId)
         const chunks = chunkArray(allFacilitiesIds, MAX_BATCH_SIZE)

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -8,6 +8,7 @@ import { updateFacilitiesWithHealthcareProfessionalIdChanges, validateIdInput } 
 import { MapDefinedFields } from '../../utils/objectUtils.js'
 import { logger } from '../logger.js'
 import { createAuditLog } from './auditLogService.js'
+import { chunkArray } from '../../utils/arrayUtils.js'
 
 /**
  * Gets the Healthcare Professional from the database that matches on the id.
@@ -585,11 +586,6 @@ export async function updateHealthcareProfessionalsWithFacilityIdChanges(
         }
 
         const MAX_BATCH_SIZE = 30
-
-        function chunkArray<T>(arr: T[], size: number): T[][] {
-            return Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
-                arr.slice(i * size, i * size + size))
-        }
 
         const allProfessionalIds = professionalRelationshipsToUpdate.map(f => f.otherEntityId)
         const chunks = chunkArray(allProfessionalIds, MAX_BATCH_SIZE)

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -600,9 +600,9 @@ export async function updateHealthcareProfessionalsWithFacilityIdChanges(
         //const professionalsQuery = dbInstance.collection('healthcareProfessionals').where('id', 'in', professionalRelationshipsToUpdate.map(f => f.otherEntityId))
         // A Firestore transaction requires all reads to happen before any writes, so we'll query all the professionals first.
         //const allProfessionalDocuments = await professionalsQuery.get()
-        const dbProfessionalsToUpdate = allProfessionalDocuments.map(d => ({
-            ref: d.ref,
-            data: d.data()
+        const dbProfessionalsToUpdate = allProfessionalDocuments.map(document => ({
+            ref: document.ref,
+            data: document.data()
         }))
 
         dbProfessionalsToUpdate.forEach(({ ref, data: dbProfessional }) => {

--- a/utils/arrayUtils.ts
+++ b/utils/arrayUtils.ts
@@ -7,3 +7,8 @@ export function removeDuplicates<T>(inputArray: T[]): T[] {
         return dedupedArray
     }, [])
 }
+
+export function chunkArray<T>(arr: T[], size: number): T[][] {
+    return Array.from({ length: Math.ceil(arr.length / size) }, (_, i) =>
+        arr.slice(i * size, i * size + size))
+}


### PR DESCRIPTION
Resolves [#830]
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

Still in working, i'm using batching and for now i've changed only `const professionalsQuery = dbInstance.collection('healthcareProfessionals').where('id', 'in', professionalRelationshipsToUpdate.map(f => f.otherEntityId))`.
same as for facilitiesQuery.

Before pushing the PR i've watched again @ermish screen ( here https://github.com/ourjapanlife/findadoc-web/issues/1138) and i've saw the problem wasn't on those line but the error was:
`ARRAY-CONTAINS-ANY support up 30 comparision`, i've checked again `FacilityService.ts` and `healthcareProfessionalService.ts` and i've understood that i wasn't fixing the right line but i have to change this

![image](https://github.com/user-attachments/assets/34875271-e4e6-427a-bf7a-2262b1c75b62)

Those line has `array-contains-any` so it is 100% where is the problem, i would ask in the first commit where you advice to me to put the function `chunkArray` because now i need to batch also those lines.

UPDATE from 4th commit, still don't know how to test with hundreds HC/Facilities but if i go to moderation page and click on a submission and try to select exist Facility what i can see from terminal is this

![image](https://github.com/user-attachments/assets/7cdf6ebf-2243-44f4-afac-fa0cbe5ff438)

i can see `healthcareProfessionalIds` that is were i used batch, app still works

## 🧪 Testing instructions

I would ask also how can i tested this in a good way? i've seen some scripts on `package.json` but i'm not sure about which is best way.
Obviously after first commit app still work perfectly.
