### PR TITLE
fix: update mapping to set additional info to empty string instead of undefined

### DIFF
--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -656,7 +656,7 @@ function mapGqlEntityToDbEntity(newHealthcareProfessionalId: string,
         createdDate: new Date().toISOString(),
         //business rule: updatedDate is updated on every change.
         updatedDate: new Date().toISOString(),
-        additionalInfoForPatients: input.additionalInfoForPatients as string
+        additionalInfoForPatients: input.additionalInfoForPatients ?? ''
     } satisfies dbSchema.HealthcareProfessional
 }
 


### PR DESCRIPTION
Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Before we casted the type as a string. This would cause it to try to add undefined as the value to the key in firestore which is not allowed. So now we set it to an empty string if undefined. This logic works for firestore and our frontend as we only display notes if it is truthy
