### PR TITLE
feat: add searchBar for facility and hc

### DIFF
--- a/src/fakeData/fakeFacilities.ts
+++ b/src/fakeData/fakeFacilities.ts
@@ -1,5 +1,6 @@
 import * as gqlTypes from '../typeDefs/gqlTypes.js'
 import { faker, fakerJA } from '@faker-js/faker'
+import { randomPrefecture } from '../../utils/japanesePrefectures.js'
 
 export function generateRandomCreateFacilityInput(healthcareProfessionalIds?: string[])
     : gqlTypes.CreateFacilityInput {
@@ -11,6 +12,8 @@ export function generateRandomCreateFacilityInput(healthcareProfessionalIds?: st
     const firstNameJa = fakerJA.person.lastName()
     const lastNameJa = fakerJA.person.lastName()
     const fullJapaneseName = fakerJA.person.fullName({ firstName: firstNameJa, lastName: lastNameJa, sex })
+
+    const { en: prefectureEn, ja: prefectureJa } = randomPrefecture()
 
     return {
         nameEn: fullEnglishName,
@@ -31,8 +34,8 @@ export function generateRandomCreateFacilityInput(healthcareProfessionalIds?: st
                 cityEn: faker.location.city(),
                 cityJa: fakerJA.location.city(),
                 postalCode: faker.location.zipCode(),
-                prefectureEn: faker.location.state(),
-                prefectureJa: fakerJA.location.state()
+                prefectureEn: prefectureEn,
+                prefectureJa: prefectureJa
             }
         }
     }

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -918,7 +918,7 @@ function mapGqlEntityToDbEntity(newHealthcareProfessionalId: string,
         createdDate: new Date().toISOString(),
         //business rule: updatedDate is updated on every change.
         updatedDate: new Date().toISOString(),
-        additionalInfoForPatients: input.additionalInfoForPatients as string
+        additionalInfoForPatients: input.additionalInfoForPatients ?? ''
     } satisfies dbSchema.HealthcareProfessional
 }
 

--- a/utils/japanesePrefectures.ts
+++ b/utils/japanesePrefectures.ts
@@ -1,0 +1,61 @@
+// utils/japanesePrefectures.ts
+export const prefectureTranslations: Record<string, string> = {
+    Hokkaido: '北海道',
+    Aomori: '青森県',
+    Iwate: '岩手県',
+    Miyagi: '宮城県',
+    Akita: '秋田県',
+    Yamagata: '山形県',
+    Fukushima: '福島県',
+    Ibaraki: '茨城県',
+    Tochigi: '栃木県',
+    Gunma: '群馬県',
+    Saitama: '埼玉県',
+    Chiba: '千葉県',
+    Tokyo: '東京都',
+    Kanagawa: '神奈川県',
+    Niigata: '新潟県',
+    Toyama: '富山県',
+    Ishikawa: '石川県',
+    Fukui: '福井県',
+    Yamanashi: '山梨県',
+    Nagano: '長野県',
+    Gifu: '岐阜県',
+    Shizuoka: '静岡県',
+    Aichi: '愛知県',
+    Mie: '三重県',
+    Shiga: '滋賀県',
+    Kyoto: '京都府',
+    Osaka: '大阪府',
+    Hyogo: '兵庫県',
+    Nara: '奈良県',
+    Wakayama: '和歌山県',
+    Tottori: '鳥取県',
+    Shimane: '島根県',
+    Okayama: '岡山県',
+    Hiroshima: '広島県',
+    Yamaguchi: '山口県',
+    Tokushima: '徳島県',
+    Kagawa: '香川県',
+    Ehime: '愛媛県',
+    Kochi: '高知県',
+    Fukuoka: '福岡県',
+    Saga: '佐賀県',
+    Nagasaki: '長崎県',
+    Kumamoto: '熊本県',
+    Oita: '大分県',
+    Miyazaki: '宮崎県',
+    Kagoshima: '鹿児島県',
+    Okinawa: '沖縄県'
+}
+
+export const randomPrefecture = (): { en: string; ja: string } => {
+    const keys = Object.keys(prefectureTranslations)
+
+    const randomKey = keys[Math.floor(Math.random() * keys.length)]
+
+    return {
+        en: randomKey,
+        ja: prefectureTranslations[randomKey]!
+    }
+}


### PR DESCRIPTION
Resolves #848 
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

Related to this Pr: https://github.com/ourjapanlife/findadoc-web/pull/1408

## 🔧 What changed

This PR start with the commits from 27 July, previous commits are due because i was using like a main branch `davide/pagination-connection-be` because is were i do all the batching for the query and i didn't want to have conflict in this PR.

`FacilityService.ts` : Changes the way i search for name, manage the code a little bit because Firestore has some limitations with query 'OR'

`HealthcareProfessionalService` : Same as Facility but here i found more issues, what is the difference beetween Facility and HCProfessionals is because these Data are different on how they store names, so with HCProfessional we couldn't use `'orderBy'`

## 🧪 Testing instructions
