### PR TITLE
fix: change permission scope for creating submission

### DIFF
--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -99,7 +99,7 @@ describe('authorize()', () => {
         // users should have access to user scopes
         expect(authorize(adminUser, [Scope['read:healthcareprofessionals']])).toBe(true)
         expect(authorize(adminUser, [Scope['read:facilities']])).toBe(true)
-        expect(authorize(adminUser, [Scope['write:submissions']])).toBe(true)
+        expect(authorize(adminUser, [Scope['create:submissions']])).toBe(true)
         expect(authorize(adminUser, [Scope['read:profile']])).toBe(true)
     })
 
@@ -119,6 +119,7 @@ describe('authorize()', () => {
         expect(authorize(adminUser, [Scope['write:facilities']])).toBe(false)
         expect(authorize(adminUser, [Scope['delete:facilities']])).toBe(false)
         expect(authorize(adminUser, [Scope['read:submissions']])).toBe(false)
+        expect(authorize(adminUser, [Scope['write:submissions']])).toBe(false)
         expect(authorize(adminUser, [Scope['delete:submissions']])).toBe(false)
         expect(authorize(adminUser, [Scope['read:users']])).toBe(false)
         expect(authorize(adminUser, [Scope['write:users']])).toBe(false)
@@ -237,7 +238,7 @@ describe('roleScopes invariant: no accidental changes', () => {
         [Role.User]: [
             Scope['read:healthcareprofessionals'],
             Scope['read:facilities'],
-            Scope['write:submissions'],
+            Scope['create:submissions'],
             Scope['read:profile']
         ]
     }

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -33,7 +33,8 @@ export enum Scope {
     'write:posts' = 'write:posts',
     'read:users' = 'read:users',
     'write:users' = 'write:users',
-    'delete:users' = 'delete:users'
+    'delete:users' = 'delete:users',
+    'create:submissions' = 'create:submissions'
 }
 
 // These are the different permissions or "scopes" that are associated with each role.
@@ -69,7 +70,7 @@ const roleScopes: Record<Role, Scope[]> = {
     [Role.User]: [
         Scope['read:healthcareprofessionals'], 
         Scope['read:facilities'], 
-        Scope['write:submissions'],
+        Scope['create:submissions'],
         Scope['read:profile']
     ]
 }

--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -251,7 +251,7 @@ const resolvers = {
         createSubmission: async (_parent: unknown, args: {
             input: gqlType.CreateSubmissionInput
         }, context: UserContext): Promise<gqlType.Submission> => {
-            const isAuthorized = authorize(context.user, [Scope['write:submissions']])
+            const isAuthorized = authorize(context.user, [Scope['write:submissions'], Scope['create:submissions']])
             
             if (!isAuthorized) {
                 throw new GraphQLError('User is not authorized', {


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
The auth in our backend did not match our store which disallowed generic users to create submissions in prod
