### PR TITLE
fix: update isAuthorized to use conditional due to functionality

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -318,7 +318,7 @@ const resolvers = {
         createSubmission: async (_parent: unknown, args: {
             input: gqlType.CreateSubmissionInput
         }, context: UserContext): Promise<gqlType.Submission> => {
-            const isAuthorized = authorize(context.user, [Scope['write:submissions'], Scope['create:submissions']])
+            const isAuthorized = authorize(context.user, [Scope['write:submissions']]) || authorize(context.user, [Scope['create:submissions']])
 
             if (!isAuthorized) {
                 throw new GraphQLError('User is not authorized', {


### PR DESCRIPTION
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Previously we were thinking the authorize function allows if any scope is allowed. But it is if you need a combination of scopes in the array to allow. So this adds a conditional that checks for two different scopes
