### PR TITLE
fix: update website validation to match front

### DIFF
--- a/utils/stringUtils.ts
+++ b/utils/stringUtils.ts
@@ -24,7 +24,7 @@ export function isValidPhoneNumber(phoneNumber: string) {
 }
 
 export function isValidWebsite(website: string) {
-    return /^((https?|ftp|smtp):\/\/)?(www.)?[a-z0-9-]+\.[a-zA-Z0-9-_#/]+$/g.test(website)
+    return /^((https?:\/\/)?([a-z0-9-]+\.)+[a-z0-9-]{2,}(\/[a-z0-9\-._~:/?#[\]@!$&'()*+,;=]*)?)?$/.test(website)
 }
 
 export function hasScriptTags(input: string) {


### PR DESCRIPTION
Resolves this [issue](https://github.com/ourjapanlife/findadoc-web/issues/1455), change for front has been merged.
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed
Regex for `isValidWebsite` in `utils/stringUtils.ts` previously accepted only single level domains.

Updated the RegEx to solve the issue as well as other potential edge cases. 

1. Accepts multi-level domain urls like `example.or.jp`
2. Rejects invalid TLD characters like `_#/`, e.g. `example.c#`
3. Accepts paths and queries `example.com/login`
4. Case-sensitive domain and TLD ~~Not case-sensitive (need clarification on this change, necessitates sanitization on backend(or front))~~
5. Also removed smtp and ftp protocol validation, I am assuming only web addresses i.e. https and http urls are accepted. Let me know if you want to keep them.

## 🧪 Testing instructions
1. Submit API request to create a facility with a valid multi-level domain/additional path/all lowercase. 
2. If successful, endpoint is working as intended. 
3. Test with invalid inputs as well i.e. uppercase, invalid TLD characters
