### PR TITLE
fix: add 々 for japanese hp names

### DIFF
--- a/utils/stringUtils.ts
+++ b/utils/stringUtils.ts
@@ -4,7 +4,7 @@ export function hasSpecialCharacters(str: string) {
 }
 
 export function hasJapaneseCharacters(name: string) {
-    return /[\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]+/g.test(name)
+    return /[\u3005\u3040-\u309f\u30a0-\u30ff\u4e00-\u9faf]+/g.test(name)
 }
 
 export function hasLatinCharacters(name: string) {


### PR DESCRIPTION
Resolves #[Issue number]
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

Add `々` with code `\u3005` inside `hasJapaneseCharacters` on backend, now our healthcare professional can contains character like 々 in their names

## 🧪 Testing instructions
