### PR TITLE
fix: doubled specialties lenght

### DIFF
--- a/src/validation/validationHealthcareProfessional.ts
+++ b/src/validation/validationHealthcareProfessional.ts
@@ -311,7 +311,7 @@ export function validateSpecialties(
         return
     }
 
-    if (specialties.length > 16) {
+    if (specialties.length > 32) {
         validationResults.hasErrors = true
         validationResults.errors?.push({
             field: 'specialties',


### PR DESCRIPTION
Resolves No issue number
- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

After this comment:
I just confirmed that reducing the amount of specialties fixed this bug. Through my vigorous limit testing, I revealed 16 is the max you can input before the system bugs out
Made by moderators, i've thought it was a good idea to double de length of specialties
## 🧪 Testing instructions
