### PR TITLE
feat: create new reservation table, reserverationService, graphql resolvers, and domain model

### DIFF
--- a/__tests__/auth.test.ts
+++ b/__tests__/auth.test.ts
@@ -43,6 +43,8 @@ describe('authorize()', () => {
         expect(authorize(adminUser, [Scope['write:posts']])).toBe(true)
         expect(authorize(adminUser, [Scope['read:logs']])).toBe(true)
         expect(authorize(adminUser, [Scope['write:logs']])).toBe(true)
+        expect(authorize(adminUser, [Scope['read:reservations']])).toBe(true)
+        expect(authorize(adminUser, [Scope['write:reservations']])).toBe(true)
     })
 
     it('should allow Moderator to access moderator scopes', () => {
@@ -67,6 +69,8 @@ describe('authorize()', () => {
         expect(authorize(adminUser, [Scope['delete:submissions']])).toBe(true)
         expect(authorize(adminUser, [Scope['read:profile']])).toBe(true)
         expect(authorize(adminUser, [Scope['write:posts']])).toBe(true)
+        expect(authorize(adminUser, [Scope['read:reservations']])).toBe(true)
+        expect(authorize(adminUser, [Scope['write:reservations']])).toBe(true)
     })
 
     it('should not allow Moderator to access admin scopes', () => {
@@ -101,6 +105,8 @@ describe('authorize()', () => {
         expect(authorize(adminUser, [Scope['read:facilities']])).toBe(true)
         expect(authorize(adminUser, [Scope['create:submissions']])).toBe(true)
         expect(authorize(adminUser, [Scope['read:profile']])).toBe(true)
+        expect(authorize(adminUser, [Scope['read:reservations']])).toBe(true)
+        expect(authorize(adminUser, [Scope['write:reservations']])).toBe(true)
     })
 
     it('should not allow User to access moderator or admin scopes', () => {
@@ -217,14 +223,16 @@ describe('roleScopes invariant: no accidental changes', () => {
             Scope['read:users'], Scope['write:users'], Scope['delete:users'],
             Scope['read:profile'],
             Scope['write:posts'],
-            Scope['read:logs'], Scope['write:logs']
+            Scope['read:logs'], Scope['write:logs'],
+            Scope['read:reservations'], Scope['write:reservations']
         ],
         [Role.Moderator]: [
             Scope['read:healthcareprofessionals'], Scope['write:healthcareprofessionals'], Scope['delete:healthcareprofessionals'],
             Scope['read:facilities'], Scope['write:facilities'], Scope['delete:facilities'],
             Scope['read:submissions'], Scope['write:submissions'], Scope['delete:submissions'],
             Scope['read:profile'],
-            Scope['write:posts']
+            Scope['write:posts'],
+            Scope['read:reservations'], Scope['write:reservations']
         ],
         [Role.Dev]: [
             Scope['read:healthcareprofessionals'], Scope['write:healthcareprofessionals'], Scope['delete:healthcareprofessionals'],
@@ -233,13 +241,15 @@ describe('roleScopes invariant: no accidental changes', () => {
             Scope['read:users'], Scope['write:users'], Scope['delete:users'],
             Scope['read:profile'], 
             Scope['write:posts'],
-            Scope['read:logs'], Scope['write:logs']
+            Scope['read:logs'], Scope['write:logs'],
+            Scope['read:reservations'], Scope['write:reservations']
         ],
         [Role.User]: [
             Scope['read:healthcareprofessionals'],
             Scope['read:facilities'],
             Scope['create:submissions'],
-            Scope['read:profile']
+            Scope['read:profile'],
+            Scope['read:reservations'], Scope['write:reservations']
         ]
     }
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -34,7 +34,9 @@ export enum Scope {
     'read:users' = 'read:users',
     'write:users' = 'write:users',
     'delete:users' = 'delete:users',
-    'create:submissions' = 'create:submissions'
+    'create:submissions' = 'create:submissions',
+    'read:reservations' = 'read:reservations',
+    'write:reservations' = 'write:reservations'
 }
 
 // These are the different permissions or "scopes" that are associated with each role.
@@ -49,14 +51,16 @@ const roleScopes: Record<Role, Scope[]> = {
         Scope['read:users'], Scope['write:users'], Scope['delete:users'],
         Scope['read:profile'], 
         Scope['write:posts'],
-        Scope['read:logs'], Scope['write:logs']
+        Scope['read:logs'], Scope['write:logs'],
+        Scope['read:reservations'], Scope['write:reservations']
     ],
     [Role.Moderator]: [
         Scope['read:healthcareprofessionals'], Scope['write:healthcareprofessionals'], Scope['delete:healthcareprofessionals'],
         Scope['read:facilities'], Scope['write:facilities'], Scope['delete:facilities'],
         Scope['read:submissions'], Scope['write:submissions'], Scope['delete:submissions'],
         Scope['read:profile'], 
-        Scope['write:posts']
+        Scope['write:posts'],
+        Scope['read:reservations'], Scope['write:reservations']
     ],
     [Role.Dev]: [
         Scope['read:healthcareprofessionals'], Scope['write:healthcareprofessionals'], Scope['delete:healthcareprofessionals'],
@@ -65,13 +69,15 @@ const roleScopes: Record<Role, Scope[]> = {
         Scope['read:users'], Scope['write:users'], Scope['delete:users'],
         Scope['read:profile'], 
         Scope['write:posts'],
-        Scope['read:logs'], Scope['write:logs']
+        Scope['read:logs'], Scope['write:logs'],
+        Scope['read:reservations'], Scope['write:reservations']
     ],
     [Role.User]: [
         Scope['read:healthcareprofessionals'], 
         Scope['read:facilities'], 
         Scope['create:submissions'],
-        Scope['read:profile']
+        Scope['read:profile'],
+        Scope['read:reservations'], Scope['write:reservations']
     ]
 }
 

--- a/src/services/reservationService.ts
+++ b/src/services/reservationService.ts
@@ -1,0 +1,89 @@
+import * as gqlTypes from '../typeDefs/gqlTypes.js'
+import { ErrorCode, Result } from '../result.js'
+import { logger } from '../logger.js'
+import * as userService from './userService.js'
+
+// temporarily using in-memory database for testing reservation service before using Supabase
+const reservations: Array<gqlTypes.Reservation> = []
+
+/**
+ * Gets a reservation from the database that matches on the id.
+ * @param id A string that matches the id of the Reservation.
+ * @returns A Reservation object.
+ */
+export async function getReservationById(id: string)
+    : Promise<Result<gqlTypes.Reservation>> {
+    try {
+        const selectedReservation = reservations.find(r => r.id === id)
+
+        if (!selectedReservation) {
+            throw new Error(`No reservation found with id: ${id}`)
+        }
+        return {
+            data: selectedReservation,
+            hasErrors: false
+        }
+    } catch (error) {
+        logger.error(`ERROR: Error getting user by id: ${error}`)
+
+        return {
+            data: {} as gqlTypes.Reservation,
+            hasErrors: true,
+            errors: [{
+                field: 'getReservationById',
+                errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
+                httpStatus: 500
+            }]
+        }
+    }
+}
+
+/**
+ * Creates a Reservation.
+ * @param input the new Reservation object
+ * @returns the newly created Reservation so you don't have to query it after
+ */
+export async function createReservation(
+    input: gqlTypes.CreateReservationInput
+): Promise<Result<gqlTypes.Reservation>> {
+    try {
+        // check if user exists that is trying to make reservation
+        const userResult = await userService.getUserById(input.userId)
+        const userData = userResult.data
+
+        if (userData.id !== input.userId) {
+            throw new Error('No user exists with that id')
+        }
+
+        const newCreatedDate = new Date().toISOString()
+        const newUpdatedDate = new Date().toISOString()
+        const newIdNum = reservations.length + 1
+        const newId = String(newIdNum)
+
+        const createdReservationResult:gqlTypes.Reservation = {
+            createdDate: newCreatedDate,
+            id: newId,
+            status: gqlTypes.ReservationStatus.Booked,
+            updatedDate: newUpdatedDate,
+            userId: input.userId
+        }
+
+        reservations.push(createdReservationResult)
+        return {
+            data: createdReservationResult,
+            hasErrors: false
+        }
+    } catch (error) {
+        logger.error(`ERROR: Error creating reservation: ${error}`)
+
+        return {
+            data: {} as gqlTypes.Reservation,
+            hasErrors: true,
+            errors: [{
+                field: 'createReservation',
+                errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
+                httpStatus: 500
+            }]
+        }
+    }
+}

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -70,6 +70,10 @@ export type CreateHealthcareProfessionalInput = {
   spokenLanguages?: InputMaybe<Array<Locale>>;
 };
 
+export type CreateReservationInput = {
+  userId: Scalars['ID']['input'];
+};
+
 export type CreateSubmissionInput = {
   autofillPlaceFromSubmissionUrl?: InputMaybe<Scalars['Boolean']['input']>;
   googleMapsUrl?: InputMaybe<Scalars['String']['input']>;
@@ -289,6 +293,7 @@ export type Mutation = {
   __typename?: 'Mutation';
   createFacility: Facility;
   createHealthcareProfessional: HealthcareProfessional;
+  createReservation: Reservation;
   createSubmission: Submission;
   createUser: User;
   deleteFacility: DeleteResult;
@@ -297,6 +302,7 @@ export type Mutation = {
   moderationPanelUpdateSubmission: Submission;
   updateFacility: Facility;
   updateHealthcareProfessional: HealthcareProfessional;
+  updateReservation: Reservation;
   updateSubmission: Submission;
   updateUser: User;
 };
@@ -309,6 +315,11 @@ export type MutationCreateFacilityArgs = {
 
 export type MutationCreateHealthcareProfessionalArgs = {
   input: CreateHealthcareProfessionalInput;
+};
+
+
+export type MutationCreateReservationArgs = {
+  input: CreateReservationInput;
 };
 
 
@@ -351,6 +362,11 @@ export type MutationUpdateFacilityArgs = {
 export type MutationUpdateHealthcareProfessionalArgs = {
   id: Scalars['ID']['input'];
   input: UpdateHealthcareProfessionalInput;
+};
+
+
+export type MutationUpdateReservationArgs = {
+  input: UpdateReservationInput;
 };
 
 
@@ -414,6 +430,7 @@ export type Query = {
   healthcareProfessional?: Maybe<HealthcareProfessional>;
   healthcareProfessionals: Array<HealthcareProfessional>;
   healthcareProfessionalsTotalCount: Scalars['Int']['output'];
+  reservation?: Maybe<Reservation>;
   submission?: Maybe<Submission>;
   submissions: Array<Submission>;
   submissionsTotalCount: Scalars['Int']['output'];
@@ -453,6 +470,11 @@ export type QueryHealthcareProfessionalsArgs = {
 
 export type QueryHealthcareProfessionalsTotalCountArgs = {
   filters: HealthcareProfessionalSearchFilters;
+};
+
+
+export type QueryReservationArgs = {
+  id: Scalars['ID']['input'];
 };
 
 
@@ -607,6 +629,11 @@ export type UpdateHealthcareProfessionalInput = {
   spokenLanguages?: InputMaybe<Array<Locale>>;
 };
 
+export type UpdateReservationInput = {
+  status: ReservationStatus;
+  userId: Scalars['ID']['input'];
+};
+
 export type UpdateSubmissionInput = {
   autofillPlaceFromSubmissionUrl?: InputMaybe<Scalars['Boolean']['input']>;
   facility?: InputMaybe<CreateFacilityInput>;
@@ -712,6 +739,7 @@ export type ResolversTypes = {
   ContactInput: ContactInput;
   CreateFacilityInput: CreateFacilityInput;
   CreateHealthcareProfessionalInput: CreateHealthcareProfessionalInput;
+  CreateReservationInput: CreateReservationInput;
   CreateSubmissionInput: CreateSubmissionInput;
   CreateUserInput: CreateUserInput;
   DayOfTheWeek: DayOfTheWeek;
@@ -750,6 +778,7 @@ export type ResolversTypes = {
   SubmissionSearchFilters: SubmissionSearchFilters;
   UpdateFacilityInput: UpdateFacilityInput;
   UpdateHealthcareProfessionalInput: UpdateHealthcareProfessionalInput;
+  UpdateReservationInput: UpdateReservationInput;
   UpdateSubmissionInput: UpdateSubmissionInput;
   UpdateUserInput: UpdateUserInput;
   User: ResolverTypeWrapper<User>;
@@ -763,6 +792,7 @@ export type ResolversParentTypes = {
   ContactInput: ContactInput;
   CreateFacilityInput: CreateFacilityInput;
   CreateHealthcareProfessionalInput: CreateHealthcareProfessionalInput;
+  CreateReservationInput: CreateReservationInput;
   CreateSubmissionInput: CreateSubmissionInput;
   CreateUserInput: CreateUserInput;
   DeleteResult: DeleteResult;
@@ -790,6 +820,7 @@ export type ResolversParentTypes = {
   SubmissionSearchFilters: SubmissionSearchFilters;
   UpdateFacilityInput: UpdateFacilityInput;
   UpdateHealthcareProfessionalInput: UpdateHealthcareProfessionalInput;
+  UpdateReservationInput: UpdateReservationInput;
   UpdateSubmissionInput: UpdateSubmissionInput;
   UpdateUserInput: UpdateUserInput;
   User: User;
@@ -882,6 +913,7 @@ export type LocalizedNameResolvers<ContextType = any, ParentType extends Resolve
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = {
   createFacility?: Resolver<ResolversTypes['Facility'], ParentType, ContextType, RequireFields<MutationCreateFacilityArgs, 'input'>>;
   createHealthcareProfessional?: Resolver<ResolversTypes['HealthcareProfessional'], ParentType, ContextType, RequireFields<MutationCreateHealthcareProfessionalArgs, 'input'>>;
+  createReservation?: Resolver<ResolversTypes['Reservation'], ParentType, ContextType, RequireFields<MutationCreateReservationArgs, 'input'>>;
   createSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationCreateSubmissionArgs, 'input'>>;
   createUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'input'>>;
   deleteFacility?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteFacilityArgs, 'id'>>;
@@ -890,6 +922,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   moderationPanelUpdateSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationModerationPanelUpdateSubmissionArgs, 'input'>>;
   updateFacility?: Resolver<ResolversTypes['Facility'], ParentType, ContextType, RequireFields<MutationUpdateFacilityArgs, 'id' | 'input'>>;
   updateHealthcareProfessional?: Resolver<ResolversTypes['HealthcareProfessional'], ParentType, ContextType, RequireFields<MutationUpdateHealthcareProfessionalArgs, 'id' | 'input'>>;
+  updateReservation?: Resolver<ResolversTypes['Reservation'], ParentType, ContextType, RequireFields<MutationUpdateReservationArgs, 'input'>>;
   updateSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationUpdateSubmissionArgs, 'id' | 'input'>>;
   updateUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdateUserArgs, 'input'>>;
 };
@@ -915,6 +948,7 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   healthcareProfessional?: Resolver<Maybe<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, RequireFields<QueryHealthcareProfessionalArgs, 'id'>>;
   healthcareProfessionals?: Resolver<Array<ResolversTypes['HealthcareProfessional']>, ParentType, ContextType, RequireFields<QueryHealthcareProfessionalsArgs, 'filters'>>;
   healthcareProfessionalsTotalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType, RequireFields<QueryHealthcareProfessionalsTotalCountArgs, 'filters'>>;
+  reservation?: Resolver<Maybe<ResolversTypes['Reservation']>, ParentType, ContextType, RequireFields<QueryReservationArgs, 'id'>>;
   submission?: Resolver<Maybe<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<QuerySubmissionArgs, 'id'>>;
   submissions?: Resolver<Array<ResolversTypes['Submission']>, ParentType, ContextType, RequireFields<QuerySubmissionsArgs, 'filters'>>;
   submissionsTotalCount?: Resolver<ResolversTypes['Int'], ParentType, ContextType, RequireFields<QuerySubmissionsTotalCountArgs, 'filters'>>;

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -83,6 +83,16 @@ export type CreateUserInput = {
   profilePicUrl?: InputMaybe<Scalars['String']['input']>;
 };
 
+export enum DayOfTheWeek {
+  Fri = 'FRI',
+  Mon = 'MON',
+  Sat = 'SAT',
+  Sun = 'SUN',
+  Thur = 'THUR',
+  Tue = 'TUE',
+  Wed = 'WED'
+}
+
 export enum Degree {
   Cnm = 'CNM',
   Dc = 'DC',
@@ -160,6 +170,15 @@ export type HealthcareProfessional = {
   specialties: Array<Specialty>;
   spokenLanguages: Array<Locale>;
   updatedDate: Scalars['String']['output'];
+};
+
+export type HealthcareProfessionalAvailability = {
+  __typename?: 'HealthcareProfessionalAvailability';
+  dayOfTheWeek: DayOfTheWeek;
+  endTime: Scalars['String']['output'];
+  hpId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  startTime: Scalars['String']['output'];
 };
 
 export type HealthcareProfessionalSearchFilters = {
@@ -476,6 +495,31 @@ export enum RelationshipAction {
   Update = 'UPDATE'
 }
 
+export type Reservation = {
+  __typename?: 'Reservation';
+  createdDate: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  slotId: Scalars['ID']['output'];
+  status: ReservationStatus;
+  updatedDate: Scalars['String']['output'];
+  userId: Scalars['ID']['output'];
+};
+
+export type ReservationSlot = {
+  __typename?: 'ReservationSlot';
+  endTime: Scalars['String']['output'];
+  hpId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  isBooked: Scalars['Boolean']['output'];
+  startTime: Scalars['String']['output'];
+};
+
+export enum ReservationStatus {
+  Booked = 'BOOKED',
+  Cancelled = 'CANCELLED',
+  Completed = 'COMPLETED'
+}
+
 export enum SchemaVersion {
   V1 = 'V1'
 }
@@ -689,6 +733,7 @@ export type ResolversTypes = {
   CreateHealthcareProfessionalInput: CreateHealthcareProfessionalInput;
   CreateSubmissionInput: CreateSubmissionInput;
   CreateUserInput: CreateUserInput;
+  DayOfTheWeek: DayOfTheWeek;
   Degree: Degree;
   DeleteResult: ResolverTypeWrapper<DeleteResult>;
   Facility: ResolverTypeWrapper<Facility>;
@@ -696,6 +741,7 @@ export type ResolversTypes = {
   FacilitySubmission: ResolverTypeWrapper<FacilitySubmission>;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   HealthcareProfessional: ResolverTypeWrapper<HealthcareProfessional>;
+  HealthcareProfessionalAvailability: ResolverTypeWrapper<HealthcareProfessionalAvailability>;
   HealthcareProfessionalSearchFilters: HealthcareProfessionalSearchFilters;
   HealthcareProfessionalSubmission: ResolverTypeWrapper<HealthcareProfessionalSubmission>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
@@ -714,6 +760,9 @@ export type ResolversTypes = {
   Query: ResolverTypeWrapper<{}>;
   Relationship: Relationship;
   RelationshipAction: RelationshipAction;
+  Reservation: ResolverTypeWrapper<Reservation>;
+  ReservationSlot: ResolverTypeWrapper<ReservationSlot>;
+  ReservationStatus: ReservationStatus;
   SchemaVersion: SchemaVersion;
   Specialty: Specialty;
   SpecialtyCategory: SpecialtyCategory;
@@ -743,6 +792,7 @@ export type ResolversParentTypes = {
   FacilitySubmission: FacilitySubmission;
   Float: Scalars['Float']['output'];
   HealthcareProfessional: HealthcareProfessional;
+  HealthcareProfessionalAvailability: HealthcareProfessionalAvailability;
   HealthcareProfessionalSearchFilters: HealthcareProfessionalSearchFilters;
   HealthcareProfessionalSubmission: HealthcareProfessionalSubmission;
   ID: Scalars['ID']['output'];
@@ -756,6 +806,8 @@ export type ResolversParentTypes = {
   PhysicalAddressInput: PhysicalAddressInput;
   Query: {};
   Relationship: Relationship;
+  Reservation: Reservation;
+  ReservationSlot: ReservationSlot;
   String: Scalars['String']['output'];
   Submission: Submission;
   SubmissionSearchFilters: SubmissionSearchFilters;
@@ -830,6 +882,15 @@ export type HealthcareProfessionalResolvers<ContextType = any, ParentType extend
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
+export type HealthcareProfessionalAvailabilityResolvers<ContextType = any, ParentType extends ResolversParentTypes['HealthcareProfessionalAvailability'] = ResolversParentTypes['HealthcareProfessionalAvailability']> = {
+  dayOfTheWeek?: Resolver<ResolversTypes['DayOfTheWeek'], ParentType, ContextType>;
+  endTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hpId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type HealthcareProfessionalSubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['HealthcareProfessionalSubmission'] = ResolversParentTypes['HealthcareProfessionalSubmission']> = {
   acceptedInsurance?: Resolver<Maybe<Array<ResolversTypes['Insurance']>>, ParentType, ContextType>;
   additionalInfoForPatients?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -892,6 +953,25 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
   user?: Resolver<Maybe<ResolversTypes['User']>, ParentType, ContextType, RequireFields<QueryUserArgs, 'id'>>;
 };
 
+export type ReservationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Reservation'] = ResolversParentTypes['Reservation']> = {
+  createdDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  slotId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  status?: Resolver<ResolversTypes['ReservationStatus'], ParentType, ContextType>;
+  updatedDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
+export type ReservationSlotResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReservationSlot'] = ResolversParentTypes['ReservationSlot']> = {
+  endTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  hpId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  isBooked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
+  startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+};
+
 export type SubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['Submission'] = ResolversParentTypes['Submission']> = {
   autofillPlaceFromSubmissionUrl?: Resolver<Maybe<ResolversTypes['Boolean']>, ParentType, ContextType>;
   createdDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
@@ -925,11 +1005,14 @@ export type Resolvers<ContextType = any> = {
   Facility?: FacilityResolvers<ContextType>;
   FacilitySubmission?: FacilitySubmissionResolvers<ContextType>;
   HealthcareProfessional?: HealthcareProfessionalResolvers<ContextType>;
+  HealthcareProfessionalAvailability?: HealthcareProfessionalAvailabilityResolvers<ContextType>;
   HealthcareProfessionalSubmission?: HealthcareProfessionalSubmissionResolvers<ContextType>;
   LocalizedName?: LocalizedNameResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   PhysicalAddress?: PhysicalAddressResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
+  Reservation?: ReservationResolvers<ContextType>;
+  ReservationSlot?: ReservationSlotResolvers<ContextType>;
   Submission?: SubmissionResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -87,16 +87,6 @@ export type CreateUserInput = {
   profilePicUrl?: InputMaybe<Scalars['String']['input']>;
 };
 
-export enum DayOfTheWeek {
-  Fri = 'FRI',
-  Mon = 'MON',
-  Sat = 'SAT',
-  Sun = 'SUN',
-  Thur = 'THUR',
-  Tue = 'TUE',
-  Wed = 'WED'
-}
-
 export enum Degree {
   Cnm = 'CNM',
   Dc = 'DC',
@@ -742,7 +732,6 @@ export type ResolversTypes = {
   CreateReservationInput: CreateReservationInput;
   CreateSubmissionInput: CreateSubmissionInput;
   CreateUserInput: CreateUserInput;
-  DayOfTheWeek: DayOfTheWeek;
   Degree: Degree;
   DeleteResult: ResolverTypeWrapper<DeleteResult>;
   Facility: ResolverTypeWrapper<Facility>;

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -172,15 +172,6 @@ export type HealthcareProfessional = {
   updatedDate: Scalars['String']['output'];
 };
 
-export type HealthcareProfessionalAvailability = {
-  __typename?: 'HealthcareProfessionalAvailability';
-  dayOfTheWeek: DayOfTheWeek;
-  endTime: Scalars['String']['output'];
-  hpId: Scalars['ID']['output'];
-  id: Scalars['ID']['output'];
-  startTime: Scalars['String']['output'];
-};
-
 export type HealthcareProfessionalSearchFilters = {
   acceptedInsurance?: InputMaybe<Array<Insurance>>;
   createdDate?: InputMaybe<Scalars['String']['input']>;
@@ -499,19 +490,9 @@ export type Reservation = {
   __typename?: 'Reservation';
   createdDate: Scalars['String']['output'];
   id: Scalars['ID']['output'];
-  slotId: Scalars['ID']['output'];
   status: ReservationStatus;
   updatedDate: Scalars['String']['output'];
   userId: Scalars['ID']['output'];
-};
-
-export type ReservationSlot = {
-  __typename?: 'ReservationSlot';
-  endTime: Scalars['String']['output'];
-  hpId: Scalars['ID']['output'];
-  id: Scalars['ID']['output'];
-  isBooked: Scalars['Boolean']['output'];
-  startTime: Scalars['String']['output'];
 };
 
 export enum ReservationStatus {
@@ -741,7 +722,6 @@ export type ResolversTypes = {
   FacilitySubmission: ResolverTypeWrapper<FacilitySubmission>;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
   HealthcareProfessional: ResolverTypeWrapper<HealthcareProfessional>;
-  HealthcareProfessionalAvailability: ResolverTypeWrapper<HealthcareProfessionalAvailability>;
   HealthcareProfessionalSearchFilters: HealthcareProfessionalSearchFilters;
   HealthcareProfessionalSubmission: ResolverTypeWrapper<HealthcareProfessionalSubmission>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
@@ -761,7 +741,6 @@ export type ResolversTypes = {
   Relationship: Relationship;
   RelationshipAction: RelationshipAction;
   Reservation: ResolverTypeWrapper<Reservation>;
-  ReservationSlot: ResolverTypeWrapper<ReservationSlot>;
   ReservationStatus: ReservationStatus;
   SchemaVersion: SchemaVersion;
   Specialty: Specialty;
@@ -792,7 +771,6 @@ export type ResolversParentTypes = {
   FacilitySubmission: FacilitySubmission;
   Float: Scalars['Float']['output'];
   HealthcareProfessional: HealthcareProfessional;
-  HealthcareProfessionalAvailability: HealthcareProfessionalAvailability;
   HealthcareProfessionalSearchFilters: HealthcareProfessionalSearchFilters;
   HealthcareProfessionalSubmission: HealthcareProfessionalSubmission;
   ID: Scalars['ID']['output'];
@@ -807,7 +785,6 @@ export type ResolversParentTypes = {
   Query: {};
   Relationship: Relationship;
   Reservation: Reservation;
-  ReservationSlot: ReservationSlot;
   String: Scalars['String']['output'];
   Submission: Submission;
   SubmissionSearchFilters: SubmissionSearchFilters;
@@ -882,15 +859,6 @@ export type HealthcareProfessionalResolvers<ContextType = any, ParentType extend
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
-export type HealthcareProfessionalAvailabilityResolvers<ContextType = any, ParentType extends ResolversParentTypes['HealthcareProfessionalAvailability'] = ResolversParentTypes['HealthcareProfessionalAvailability']> = {
-  dayOfTheWeek?: Resolver<ResolversTypes['DayOfTheWeek'], ParentType, ContextType>;
-  endTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hpId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
 export type HealthcareProfessionalSubmissionResolvers<ContextType = any, ParentType extends ResolversParentTypes['HealthcareProfessionalSubmission'] = ResolversParentTypes['HealthcareProfessionalSubmission']> = {
   acceptedInsurance?: Resolver<Maybe<Array<ResolversTypes['Insurance']>>, ParentType, ContextType>;
   additionalInfoForPatients?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
@@ -956,19 +924,9 @@ export type QueryResolvers<ContextType = any, ParentType extends ResolversParent
 export type ReservationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Reservation'] = ResolversParentTypes['Reservation']> = {
   createdDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  slotId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
   status?: Resolver<ResolversTypes['ReservationStatus'], ParentType, ContextType>;
   updatedDate?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   userId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
-};
-
-export type ReservationSlotResolvers<ContextType = any, ParentType extends ResolversParentTypes['ReservationSlot'] = ResolversParentTypes['ReservationSlot']> = {
-  endTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
-  hpId?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
-  isBooked?: Resolver<ResolversTypes['Boolean'], ParentType, ContextType>;
-  startTime?: Resolver<ResolversTypes['String'], ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 };
 
@@ -1005,14 +963,12 @@ export type Resolvers<ContextType = any> = {
   Facility?: FacilityResolvers<ContextType>;
   FacilitySubmission?: FacilitySubmissionResolvers<ContextType>;
   HealthcareProfessional?: HealthcareProfessionalResolvers<ContextType>;
-  HealthcareProfessionalAvailability?: HealthcareProfessionalAvailabilityResolvers<ContextType>;
   HealthcareProfessionalSubmission?: HealthcareProfessionalSubmissionResolvers<ContextType>;
   LocalizedName?: LocalizedNameResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   PhysicalAddress?: PhysicalAddressResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;
   Reservation?: ReservationResolvers<ContextType>;
-  ReservationSlot?: ReservationSlotResolvers<ContextType>;
   Submission?: SubmissionResolvers<ContextType>;
   User?: UserResolvers<ContextType>;
 };

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -180,6 +180,15 @@ type Reservation {
   status: ReservationStatus!
 }
 
+input CreateReservationInput {
+  userId: ID!
+}
+
+input UpdateReservationInput {
+  userId: ID!
+  status: ReservationStatus!
+}
+
 enum ReservationStatus {
   BOOKED
   CANCELLED
@@ -482,6 +491,7 @@ type Query {
   submissionsTotalCount(filters: SubmissionSearchFilters!): Int!
   auditLog(id: ID): AuditLog
   user(id: ID!): User
+  reservation(id: ID!): Reservation
 }
 
 #======== Mutations ========
@@ -517,4 +527,8 @@ type Mutation {
   createUser(input: CreateUserInput!): User!
 
   updateUser(input: UpdateUserInput!): User!
+
+  createReservation(input: CreateReservationInput!): Reservation!
+
+  updateReservation(input: UpdateReservationInput!): Reservation!
 }

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -172,6 +172,47 @@ input SubmissionSearchFilters {
   offset: Int
 }
 
+type Reservation {
+  id: ID!
+  userId: ID!
+  slotId: ID!
+  createdDate: String!
+  updatedDate: String!
+  status: ReservationStatus!
+}
+
+enum ReservationStatus {
+  BOOKED
+  CANCELLED
+  COMPLETED
+}
+
+type ReservationSlot {
+  id: ID!
+  hpId: ID!
+  startTime: String!
+  endTime: String!
+  isBooked: Boolean!
+}
+
+type HealthcareProfessionalAvailability {
+  id: ID!
+  hpId: ID!
+  dayOfTheWeek: DayOfTheWeek!
+  startTime: String!
+  endTime: String!
+}
+
+enum DayOfTheWeek {
+  SUN
+  MON
+  TUE
+  WED
+  THUR
+  FRI
+  SAT
+}
+
 type User {
   id: ID!
   createdDate: String!

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -175,7 +175,6 @@ input SubmissionSearchFilters {
 type Reservation {
   id: ID!
   userId: ID!
-  slotId: ID!
   createdDate: String!
   updatedDate: String!
   status: ReservationStatus!
@@ -185,22 +184,6 @@ enum ReservationStatus {
   BOOKED
   CANCELLED
   COMPLETED
-}
-
-type ReservationSlot {
-  id: ID!
-  hpId: ID!
-  startTime: String!
-  endTime: String!
-  isBooked: Boolean!
-}
-
-type HealthcareProfessionalAvailability {
-  id: ID!
-  hpId: ID!
-  dayOfTheWeek: DayOfTheWeek!
-  startTime: String!
-  endTime: String!
 }
 
 enum DayOfTheWeek {

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -195,16 +195,6 @@ enum ReservationStatus {
   COMPLETED
 }
 
-enum DayOfTheWeek {
-  SUN
-  MON
-  TUE
-  WED
-  THUR
-  FRI
-  SAT
-}
-
 type User {
   id: ID!
   createdDate: String!


### PR DESCRIPTION
Resolves #895 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

- added the following to `schema.graphql` and `gqlTypes.ts` :
type `Reservation`, enum `ReservationStatus`, input `CreateReservationInput`, input `UpdateReservationInput`
reservation query, createReservation mutation, updateReservation mutation

-  added the following resolvers
reservation query resolver, createReservation mutation resolver


- added `reservationService.ts` to handle resolvers

- added the following new Scopes to auth.ts and put under each Role for now
`read:reservations` , `write:reservations` 

- updated auth.test.ts to include `read:reservations` and `write:reservations`



## 🧪 Testing instructions

- try to create a User with the backend
- then, try to create a reservation using a user id
- if you use an existing user id, should successfully create a reservation
- if not an existing user id, should throw an error in the server terminal saying not an existing user