### PR TITLE
feat: create update user mutation

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -430,6 +430,23 @@ const resolvers = {
 
             return createUserResult.data
         },
+        updateUser: async (_parent: unknown, args: { id: string, input: gqlType.UpdateUserInput }, context: UserContext)
+        : Promise<gqlType.User> => {
+            const isAuthorized = authorize(context.user, [Scope['write:users']])
+
+            if (!isAuthorized) {
+                throw new GraphQLError('User is not authorized', {
+                    extensions: {
+                        code: 'UNAUTHORIZED',
+                        http: { status: 403 }
+                    }
+                })
+            }
+
+            const updateUserResult = await userService.updateUser(args.id, args.input)
+
+            return updateUserResult.data
+        },
         createReservation: async (_parent: unknown, args: { input: gqlType.CreateReservationInput }, 
             context: UserContext)
         : Promise<gqlType.Reservation> => {

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -79,3 +79,51 @@ export async function createUser(
     }
 }
 
+/**
+ * Updates a User.
+ * @param input the id of the user and the fields to update
+ * @returns the updated User so you don't have to query it after
+ */
+export async function updateUser(
+    userId: string,
+    fieldsToUpdate: gqlTypes.UpdateUserInput
+): Promise<Result<gqlTypes.User>> {
+    try {
+        // check if user exists and get the array index in the database
+        const userArrayIndex = users.findIndex(u => u.id === userId)
+
+        if (userArrayIndex === -1) {
+            throw new Error('No user exists with the provided id')
+        }
+
+        // update the user using the array index
+        users[userArrayIndex] = {
+            createdDate: users[userArrayIndex].createdDate,
+            id: users[userArrayIndex].id,
+            updatedDate: new Date().toISOString(),
+            displayName: fieldsToUpdate.displayName !== undefined ? fieldsToUpdate.displayName
+                : users[userArrayIndex].displayName,
+            profilePicUrl: fieldsToUpdate.profilePicUrl !== undefined ? fieldsToUpdate.profilePicUrl
+                : users[userArrayIndex].profilePicUrl
+        }
+
+        // return the updated user
+        return {
+            data: users[userArrayIndex],
+            hasErrors: false
+        } 
+    } catch (error) {
+        logger.error(`ERROR: Error creating user: ${error}`)
+
+        return {
+            data: {} as gqlTypes.User,
+            hasErrors: true,
+            errors: [{
+                field: 'createUser',
+                errorCode: ErrorCode.INTERNAL_SERVER_ERROR,
+                httpStatus: 500
+            }]
+        }
+    }
+}
+

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -367,6 +367,7 @@ export type MutationUpdateSubmissionArgs = {
 
 
 export type MutationUpdateUserArgs = {
+  id: Scalars['ID']['input'];
   input: UpdateUserInput;
 };
 
@@ -913,7 +914,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   updateHealthcareProfessional?: Resolver<ResolversTypes['HealthcareProfessional'], ParentType, ContextType, RequireFields<MutationUpdateHealthcareProfessionalArgs, 'id' | 'input'>>;
   updateReservation?: Resolver<ResolversTypes['Reservation'], ParentType, ContextType, RequireFields<MutationUpdateReservationArgs, 'input'>>;
   updateSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationUpdateSubmissionArgs, 'id' | 'input'>>;
-  updateUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdateUserArgs, 'input'>>;
+  updateUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationUpdateUserArgs, 'id' | 'input'>>;
 };
 
 export type PhysicalAddressResolvers<ContextType = any, ParentType extends ResolversParentTypes['PhysicalAddress'] = ResolversParentTypes['PhysicalAddress']> = {

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -516,7 +516,7 @@ type Mutation {
 
   createUser(input: CreateUserInput!): User!
 
-  updateUser(input: UpdateUserInput!): User!
+  updateUser(id: ID!, input: UpdateUserInput!): User!
 
   createReservation(input: CreateReservationInput!): Reservation!
 


### PR DESCRIPTION
Resolves #907 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

- added `updateUser`, `updateUserInput` to `schema.graphql` and `gqlTypes.ts`
- added `updateUser` resolvers to `resolvers.ts`
- added an `updateUser` function to `userService.ts` that handles the logic for carrying out the update (currently still using the in memory array data base)

## 🧪 Testing instructions

- start apollo server and create a user
- try to update the user with a new display name and/or new profile pic url
