### PR TITLE
feat: deleteUser mutation for userService

### DIFF
--- a/src/resolvers.ts
+++ b/src/resolvers.ts
@@ -447,6 +447,23 @@ const resolvers = {
 
             return updateUserResult.data
         },
+        deleteUser: async (_parent: unknown, args: { id: string }, context: UserContext)
+        : Promise<gqlType.DeleteResult> => {
+            const isAuthorized = authorize(context.user, [Scope['delete:users']])
+
+            if (!isAuthorized) {
+                throw new GraphQLError('User is not authorized', {
+                    extensions: {
+                        code: 'UNAUTHORIZED',
+                        http: { status: 403 }
+                    }
+                })
+            }
+
+            const deleteUserResult = await userService.deleteUser(args.id)
+
+            return deleteUserResult.data
+        },
         createReservation: async (_parent: unknown, args: { input: gqlType.CreateReservationInput }, 
             context: UserContext)
         : Promise<gqlType.Reservation> => {

--- a/src/typeDefs/gqlTypes.ts
+++ b/src/typeDefs/gqlTypes.ts
@@ -290,6 +290,7 @@ export type Mutation = {
   deleteFacility: DeleteResult;
   deleteHealthcareProfessional: DeleteResult;
   deleteSubmission: DeleteResult;
+  deleteUser: DeleteResult;
   moderationPanelUpdateSubmission: Submission;
   updateFacility: Facility;
   updateHealthcareProfessional: HealthcareProfessional;
@@ -335,6 +336,11 @@ export type MutationDeleteHealthcareProfessionalArgs = {
 
 
 export type MutationDeleteSubmissionArgs = {
+  id: Scalars['ID']['input'];
+};
+
+
+export type MutationDeleteUserArgs = {
   id: Scalars['ID']['input'];
 };
 
@@ -912,6 +918,7 @@ export type MutationResolvers<ContextType = any, ParentType extends ResolversPar
   deleteFacility?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteFacilityArgs, 'id'>>;
   deleteHealthcareProfessional?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteHealthcareProfessionalArgs, 'id'>>;
   deleteSubmission?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteSubmissionArgs, 'id'>>;
+  deleteUser?: Resolver<ResolversTypes['DeleteResult'], ParentType, ContextType, RequireFields<MutationDeleteUserArgs, 'id'>>;
   moderationPanelUpdateSubmission?: Resolver<ResolversTypes['Submission'], ParentType, ContextType, RequireFields<MutationModerationPanelUpdateSubmissionArgs, 'input'>>;
   updateFacility?: Resolver<ResolversTypes['Facility'], ParentType, ContextType, RequireFields<MutationUpdateFacilityArgs, 'id' | 'input'>>;
   updateHealthcareProfessional?: Resolver<ResolversTypes['HealthcareProfessional'], ParentType, ContextType, RequireFields<MutationUpdateHealthcareProfessionalArgs, 'id' | 'input'>>;

--- a/src/typeDefs/schema.graphql
+++ b/src/typeDefs/schema.graphql
@@ -521,6 +521,8 @@ type Mutation {
 
   updateUser(id: ID!, input: UpdateUserInput!): User!
 
+  deleteUser(id: ID!): DeleteResult!
+
   createReservation(input: CreateReservationInput!): Reservation!
 
   updateReservation(input: UpdateReservationInput!): Reservation!


### PR DESCRIPTION
Resolves #913 
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

created a `deleteUser` mutation to the schema, resolvers, and userService. It first validates if the specified user with the id exists in supabase and if it doesn't, throws a validation error. If the user does exist, it will delete them

## 🧪 Testing instructions
Try copying one of the user ids in the user table in supabase to delete. There are multiple dummy users created from the user tests, like `rez_test_user`. Those are safe to delete to test if this PR works. You can also purposefully use wrong ids to see the error messages