### PR TITLE
chore: update findadoc server codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,4 +10,4 @@
 
 # review when someone opens a pull request.
 
-*  @ermish @aaronculbert
+*  @NabbeunNabi @aaronculbert


### PR DESCRIPTION
Resolves #[Issue number]
- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) specs

## 🔧 What changed

This updates the codeowners for the server
