### PR TITLE
fix: wrap HP update JSONB columns with asJsonb

### DIFF
--- a/__tests__/healthcareProfessional.test.ts
+++ b/__tests__/healthcareProfessional.test.ts
@@ -57,6 +57,79 @@ describe('createHealthcareProfessional', () => {
     })
 })
 
+describe('updateHealthcareProfessional', () => {
+    test('updates JSONB array fields (names, degrees, specialties, spokenLanguages, acceptedInsurance)', async () => {
+        // -- Create a professional to update --
+        const createRequest = {
+            query: createHealthcareProfessionalMutation,
+            variables: {
+                input: generateCreateProfessionalInput({ facilityIds: sharedFacilityIds })
+            }
+        } as gqlMutation<CreateHealthcareProfessionalInput>
+
+        const createResult = await request(gqlApiUrl).post('').send(createRequest)
+
+        const createErrors = createResult.body?.errors
+
+        if (createErrors) {
+            logger.error(JSON.stringify(createErrors))
+            expect(JSON.stringify(createErrors)).toBeUndefined()
+        }
+
+        const createdProfessional = createResult.body.data.createHealthcareProfessional as HealthcareProfessional
+
+        // -- Build an update payload with brand-new JSONB array values --
+        // These fields previously failed because the patch was not wrapped with asJsonb().
+        const updatedValues = generateCreateProfessionalInput({ facilityIds: sharedFacilityIds })
+
+        const updateRequest = {
+            query: updateHealthcareProfessionalMutation,
+            variables: {
+                id: createdProfessional.id,
+                input: {
+                    names: updatedValues.names,
+                    degrees: updatedValues.degrees,
+                    specialties: updatedValues.specialties,
+                    spokenLanguages: updatedValues.spokenLanguages,
+                    acceptedInsurance: updatedValues.acceptedInsurance
+                }
+            }
+        } as gqlRequest
+
+        const updateResult = await request(gqlApiUrl).post('').send(updateRequest)
+
+        // -- The mutation must succeed (previously errored with INTERNAL_SERVER_ERROR) --
+        const updateErrors = updateResult.body?.errors
+
+        if (updateErrors) {
+            logger.error(JSON.stringify(updateErrors))
+            expect(JSON.stringify(updateErrors)).toBeUndefined()
+        }
+
+        const updatedProfessional = updateResult.body.data.updateHealthcareProfessional as HealthcareProfessional
+
+        // -- Re-fetch and confirm the JSONB arrays were actually persisted --
+        const getByIdRequest = {
+            query: getHealthcareProfessionalByIdQuery,
+            variables: { id: createdProfessional.id }
+        } as gqlRequest
+
+        const getResult = await request(gqlApiUrl).post('').send(getByIdRequest)
+
+        expect(getResult.body?.errors).toBeUndefined()
+
+        const persistedProfessional = getResult.body.data.healthcareProfessional as HealthcareProfessional
+
+        expect(updatedProfessional.id).toBe(createdProfessional.id)
+        expect(persistedProfessional.names[0].firstName).toEqual(updatedValues.names[0].firstName)
+        expect(persistedProfessional.names[0].lastName).toEqual(updatedValues.names[0].lastName)
+        expect(persistedProfessional.degrees).toEqual(updatedValues.degrees)
+        expect(persistedProfessional.specialties).toEqual(updatedValues.specialties)
+        expect(persistedProfessional.spokenLanguages).toEqual(updatedValues.spokenLanguages)
+        expect(persistedProfessional.acceptedInsurance).toEqual(updatedValues.acceptedInsurance)
+    })
+})
+
 describe('deleteHealthcareProfessional', () => {
     test('deletes a new healthcare professional', async () => {
         // -- Create a new professional that we plan to delete --
@@ -453,6 +526,26 @@ describe('searchHealthcareProfessionals', () => {
 
 export const createHealthcareProfessionalMutation = `mutation test_createHealthcareProfessional($input: CreateHealthcareProfessionalInput!) {
     createHealthcareProfessional(input: $input) {
+        id
+        names {
+            lastName
+            firstName
+            middleName
+            locale
+        }
+        degrees
+        specialties
+        facilityIds
+        spokenLanguages
+        acceptedInsurance
+        createdDate
+        updatedDate
+        additionalInfoForPatients
+    }
+}`
+
+const updateHealthcareProfessionalMutation = `mutation test_updateHealthcareProfessional($id: ID!, $input: UpdateHealthcareProfessionalInput!) {
+    updateHealthcareProfessional(id: $id, input: $input) {
         id
         names {
             lastName

--- a/src/services/healthcareProfessionalService.ts
+++ b/src/services/healthcareProfessionalService.ts
@@ -15,13 +15,15 @@ type HpRow = dbSchema.DbHealthcareProfessionalRow
 
 // Builds a partial update patch for Healthcare Professional rows.
 export function buildHpUpdatePatch(fields: Partial<gqlTypes.UpdateHealthcareProfessionalInput>) {
-    const updatePatch: Partial<dbSchema.DbHealthcareProfessionalRow> = {}
+    const updatePatch: Record<string, unknown> = {}
 
-    if (fields.names !== null) { updatePatch.names = fields.names }
-    if (fields.degrees !== null) { updatePatch.degrees = fields.degrees }
-    if (fields.spokenLanguages !== null) { updatePatch.spoken_languages = fields.spokenLanguages }
-    if (fields.specialties !== null) { updatePatch.specialties = fields.specialties }
-    if (fields.acceptedInsurance !== null) { updatePatch.accepted_insurance = fields.acceptedInsurance }
+    // JSONB columns must be wrapped with asJsonb(): the pg driver serializes raw JS
+    // arrays as PostgreSQL array literals ({...}) which jsonb columns reject.
+    if (fields.names !== undefined) { updatePatch.names = asJsonb(fields.names) }
+    if (fields.degrees !== undefined) { updatePatch.degrees = asJsonb(fields.degrees) }
+    if (fields.spokenLanguages !== undefined) { updatePatch.spoken_languages = asJsonb(fields.spokenLanguages) }
+    if (fields.specialties !== undefined) { updatePatch.specialties = asJsonb(fields.specialties) }
+    if (fields.acceptedInsurance !== undefined) { updatePatch.accepted_insurance = asJsonb(fields.acceptedInsurance) }
     if (fields.additionalInfoForPatients !== undefined) {
         updatePatch.additional_info_for_patients = fields.additionalInfoForPatients
     }


### PR DESCRIPTION
## Summary

Fixes #998 — `updateHealthcareProfessional` failed with `INTERNAL_SERVER_ERROR` whenever the update included any JSONB array field (`names`, `degrees`, `specialties`, `spokenLanguages`, `acceptedInsurance`).

`buildHpUpdatePatch` assigned **raw JS arrays** to these JSONB columns. The pg driver serializes JS arrays as PostgreSQL **array literals** (`{...}`), not JSON, which `jsonb` columns reject (`invalid input syntax for type json`), so the transaction threw and the mutation returned a 500.

## Changes

- Wrap each JSONB column with `asJsonb()` — consistent with `createHealthcareProfessional` and `submissionService`, which already do this. (`asJsonb`'s docstring: *"ALWAYS use for UPDATE operations that modify JSONB columns."*)
- Change field guards from `!== null` to `!== undefined`, matching `buildFacilityUpdatePatch`. Previously, fields the client did not send (`undefined`) were still written into the patch (e.g. `updatePatch.names = undefined`), risking clobbered data and breaking the `Object.keys(updatePatch).length > 1` change-detection.
- Add an integration test for `updateHealthcareProfessional` exercising all JSONB array fields — this path previously had no test coverage.

## Verification

- Confirmed the new test **fails on `main`** (mutation returns errors) and **passes with this fix**.
- Full suite green: `228 passed (228)`.
- `npx tsc --noEmit` and `eslint` both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for healthcare professional record updates, validating array field modifications and data persistence.

* **Bug Fixes**
  * Fixed handling of healthcare professional array fields (names, degrees, specialties, spoken languages, and accepted insurance) to ensure proper data persistence during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->